### PR TITLE
[POM-84] feat: 주문 거절 시 결제 취소 

### DIFF
--- a/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
+++ b/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
@@ -15,7 +15,8 @@ public enum ExceptionMessage {
     NULL_PAYOUT_OBJECT("지급 관련 값은 필수입니다."),
     NULL_SALES_OBJECT("매출 관련 값은 필수입니다."),
     SALES_DATE_IS_AFTER_NOW("매출 일은 생성 날짜와 같거나 그보다 빨라야 합니다."),
-    PAYOUT_DATE_IS_BEFORE_NOW("지급 일은 생성 날짜와 같거나 그보다 늦어야 합니다.");
+    PAYOUT_DATE_IS_BEFORE_NOW("지급 일은 생성 날짜와 같거나 그보다 늦어야 합니다."),
+    NO_PAYMENT("해당 결제 건이 존재하지 않습니다");
 
     private final String message;
 

--- a/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
@@ -16,7 +16,7 @@ public record ReceiveOrderRequest(
         String customerPhoneNumber,
         LocalDateTime reservationTime,
         Long storeId,
-        PaymentCreateRequest paymentRequest
+        PaymentCreateRequest payment
 ) {
 
     public static Order getEntity(ReceiveOrderRequest request) {
@@ -29,16 +29,16 @@ public record ReceiveOrderRequest(
                 .customerPhoneNumber(new PhoneNumber(request.customerPhoneNumber()))
                 .reservationTime(request.reservationTime())
                 .storeId(request.storeId())
-                .paymentId(request.paymentRequest.id())
+                .paymentId(request.payment.id())
                 .build();
     }
 
     public Payment toPaymentEntity() {
         return Payment.builder()
-                .id(this.paymentRequest.id())
-                .amount(this.paymentRequest.amount())
-                .status(this.paymentRequest.status())
-                .provider(this.paymentRequest.provider())
+                .id(this.payment.id())
+                .amount(this.payment.amount())
+                .status(this.payment.status())
+                .provider(this.payment.provider())
                 .build();
     }
 

--- a/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
@@ -29,7 +29,8 @@ public record ReceiveOrderRequest(
                 .customerPhoneNumber(new PhoneNumber(this.customerPhoneNumber()))
                 .reservationTime(this.reservationTime())
                 .storeId(this.storeId())
-                .paymentId(this.paymentId())
+                .paymentId(this.payment().id())
+                .build();
     }
 
     public Payment toPaymentEntity() {

--- a/src/main/java/com/ray/pominowner/orders/domain/OrderStatus.java
+++ b/src/main/java/com/ray/pominowner/orders/domain/OrderStatus.java
@@ -2,6 +2,6 @@ package com.ray.pominowner.orders.domain;
 
 public enum OrderStatus {
 
-    CONFIRMING, COOKING, READY, CANCELLED, REJECTED
+    CONFIRMING, COOKING, READY, CANCELED, REJECTED
 
 }

--- a/src/main/java/com/ray/pominowner/orders/service/OrderService.java
+++ b/src/main/java/com/ray/pominowner/orders/service/OrderService.java
@@ -7,7 +7,6 @@ import com.ray.pominowner.payment.service.PaymentService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
 import java.util.List;

--- a/src/main/java/com/ray/pominowner/orders/service/OrderService.java
+++ b/src/main/java/com/ray/pominowner/orders/service/OrderService.java
@@ -3,6 +3,7 @@ package com.ray.pominowner.orders.service;
 import com.ray.pominowner.orders.domain.Order;
 import com.ray.pominowner.orders.domain.OrderStatus;
 import com.ray.pominowner.orders.repository.OrderRepository;
+import com.ray.pominowner.payment.service.PaymentService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ public class OrderService {
     private final ReceiptNumberGenerator generator;
 
     private final OrderRepository orderRepository;
+
+    private final PaymentService paymentService;
 
     public Order receiveOrder(Order order) {
         return orderRepository.save(order);
@@ -42,7 +45,9 @@ public class OrderService {
         Order rejectedOrder = Order.of(order,
                 OrderStatus.REJECTED,
                 "재고 소진");
+
         orderRepository.save(rejectedOrder);
+        paymentService.canceled(order.getPaymentId());
 
         return rejectedOrder;
     }

--- a/src/main/java/com/ray/pominowner/orders/service/OrderService.java
+++ b/src/main/java/com/ray/pominowner/orders/service/OrderService.java
@@ -48,7 +48,7 @@ public class OrderService {
                 "재고 소진");
 
         orderRepository.save(rejectedOrder);
-        paymentService.canceled(order.getPaymentId());
+        paymentService.cancel(order.getPaymentId());
 
         return rejectedOrder;
     }

--- a/src/main/java/com/ray/pominowner/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pominowner/payment/domain/Payment.java
@@ -53,7 +53,7 @@ public class Payment extends BaseTimeEntity {
         return Payment.builder()
                 .id(this.id)
                 .amount(this.amount)
-                .status(PaymentStatus.CANCELLED)
+                .status(PaymentStatus.CANCELED)
                 .provider(this.provider)
                 .build();
     }

--- a/src/main/java/com/ray/pominowner/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pominowner/payment/domain/Payment.java
@@ -49,6 +49,15 @@ public class Payment extends BaseTimeEntity {
         this.provider = provider;
     }
 
+    public Payment canceled() {
+        return Payment.builder()
+                .id(this.id)
+                .amount(this.amount)
+                .status(PaymentStatus.CANCELLED)
+                .provider(this.provider)
+                .build();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/ray/pominowner/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/ray/pominowner/payment/domain/PaymentStatus.java
@@ -3,6 +3,6 @@ package com.ray.pominowner.payment.domain;
 public enum PaymentStatus {
 
     COMPLETE,
-    CANCELLED
+    CANCELED
 
 }

--- a/src/main/java/com/ray/pominowner/payment/dto/PaymentCreateRequest.java
+++ b/src/main/java/com/ray/pominowner/payment/dto/PaymentCreateRequest.java
@@ -1,13 +1,7 @@
 package com.ray.pominowner.payment.dto;
 
 import com.ray.pominowner.payment.domain.PGType;
-import com.ray.pominowner.payment.domain.Payment;
 import com.ray.pominowner.payment.domain.PaymentStatus;
 
 public record PaymentCreateRequest(Long id, int amount, PaymentStatus status, PGType provider) {
-
-    public Payment toEntity() {
-        return new Payment(id, amount, status, provider);
-    }
-
 }

--- a/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
@@ -1,7 +1,6 @@
 package com.ray.pominowner.payment.service;
 
 import com.ray.pominowner.payment.domain.Payment;
-import com.ray.pominowner.payment.domain.PaymentStatus;
 import com.ray.pominowner.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,12 +24,7 @@ public class PaymentService {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException(NO_PAYMENT.getMessage()));
 
-        Payment canceled = Payment.builder()
-                .id(paymentId)
-                .amount(payment.getAmount())
-                .provider(payment.getProvider())
-                .status(PaymentStatus.CANCELLED)
-                .build();
+        Payment canceled = payment.canceled();
 
         return paymentRepository.save(canceled);
     }

--- a/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
@@ -1,21 +1,38 @@
 package com.ray.pominowner.payment.service;
 
 import com.ray.pominowner.payment.domain.Payment;
+import com.ray.pominowner.payment.domain.PaymentStatus;
 import com.ray.pominowner.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.ray.pominowner.global.util.ExceptionMessage.NO_PAYMENT;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
 
-    @Transactional
     public Payment create(Payment payment) {
         return paymentRepository.save(payment);
+    }
+
+
+    public Payment canceled(Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new IllegalArgumentException(NO_PAYMENT.getMessage()));
+
+        Payment canceled = Payment.builder()
+                .id(paymentId)
+                .amount(payment.getAmount())
+                .provider(payment.getProvider())
+                .status(PaymentStatus.CANCELLED)
+                .build();
+
+        return paymentRepository.save(canceled);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pominowner/payment/service/PaymentService.java
@@ -20,7 +20,7 @@ public class PaymentService {
     }
 
 
-    public Payment canceled(Long paymentId) {
+    public Payment cancel(Long paymentId) {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException(NO_PAYMENT.getMessage()));
 

--- a/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
@@ -90,7 +90,7 @@ class OrderServiceTest {
 
         given(orderRepository.save(order)).willReturn(order);
         given(orderRepository.findById(1L)).willReturn(Optional.ofNullable(order));
-        given(paymentService.canceled(order.getPaymentId())).willReturn(canceled);
+        given(paymentService.cancel(order.getPaymentId())).willReturn(canceled);
 
         // when
         Order rejectedOrder = orderService.reject(order.getId());

--- a/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
@@ -4,6 +4,10 @@ import com.ray.pominowner.global.domain.PhoneNumber;
 import com.ray.pominowner.orders.domain.Order;
 import com.ray.pominowner.orders.domain.OrderStatus;
 import com.ray.pominowner.orders.repository.OrderRepository;
+import com.ray.pominowner.payment.domain.PGType;
+import com.ray.pominowner.payment.domain.Payment;
+import com.ray.pominowner.payment.domain.PaymentStatus;
+import com.ray.pominowner.payment.service.PaymentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +28,9 @@ class OrderServiceTest {
     private OrderService orderService;
 
     @Mock
+    private PaymentService paymentService;
+
+    @Mock
     private OrderRepository orderRepository;
 
     @Mock
@@ -41,6 +48,7 @@ class OrderServiceTest {
                 .totalPrice(30000)
                 .customerPhoneNumber(new PhoneNumber("01012345678"))
                 .storeId(1L)
+                .paymentId(1L)
                 .build();
     }
 
@@ -78,8 +86,11 @@ class OrderServiceTest {
     @DisplayName("주문 거절을 성공한다")
     void successRejectOrder() {
         // given
+        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELLED, PGType.TOSS);
+
         given(orderRepository.save(order)).willReturn(order);
         given(orderRepository.findById(1L)).willReturn(Optional.ofNullable(order));
+        given(paymentService.canceled(order.getPaymentId())).willReturn(canceled);
 
         // when
         Order rejectedOrder = orderService.reject(order.getId());

--- a/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
@@ -86,7 +86,7 @@ class OrderServiceTest {
     @DisplayName("주문 거절을 성공한다")
     void successRejectOrder() {
         // given
-        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELLED, PGType.TOSS);
+        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELED, PGType.TOSS);
 
         given(orderRepository.save(order)).willReturn(order);
         given(orderRepository.findById(1L)).willReturn(Optional.ofNullable(order));

--- a/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
@@ -11,7 +11,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +38,36 @@ class PaymentServiceTest {
 
         // then
         assertThat(createdPayment).isEqualTo(payment);
+    }
+
+    @Test
+    @DisplayName("Payment 취소에 성공한다.")
+    public void successCancelPayment() {
+        // given
+        Payment saved = new Payment(1L, 1000, PaymentStatus.COMPLETE, PGType.TOSS);
+        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELLED, PGType.TOSS);
+
+        given(paymentRepository.findById(saved.getId())).willReturn(Optional.of(saved));
+        given(paymentRepository.save(canceled)).willReturn(canceled);
+
+        // when
+        Payment payment = paymentService.canceled(saved.getId());
+
+        // then
+        assertThat(canceled).isEqualTo(payment);
+    }
+
+    @Test
+    @DisplayName("PaymentId가 존재하지 않는 경우 취소에 실패한다.")
+    public void failCancelPayment() {
+        // given
+        Payment saved = new Payment(1L, 1000, PaymentStatus.COMPLETE, PGType.TOSS);
+
+        given(paymentRepository.findById(saved.getId())).willThrow(IllegalArgumentException.class);
+
+        // when, then
+        assertThatThrownBy(() -> paymentService.canceled(saved.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
@@ -45,7 +45,7 @@ class PaymentServiceTest {
     public void successCancelPayment() {
         // given
         Payment saved = new Payment(1L, 1000, PaymentStatus.COMPLETE, PGType.TOSS);
-        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELLED, PGType.TOSS);
+        Payment canceled = new Payment(1L, 1000, PaymentStatus.CANCELED, PGType.TOSS);
 
         given(paymentRepository.findById(saved.getId())).willReturn(Optional.of(saved));
         given(paymentRepository.save(canceled)).willReturn(canceled);

--- a/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ray/pominowner/payment/service/PaymentServiceTest.java
@@ -51,7 +51,7 @@ class PaymentServiceTest {
         given(paymentRepository.save(canceled)).willReturn(canceled);
 
         // when
-        Payment payment = paymentService.canceled(saved.getId());
+        Payment payment = paymentService.cancel(saved.getId());
 
         // then
         assertThat(canceled).isEqualTo(payment);
@@ -66,7 +66,7 @@ class PaymentServiceTest {
         given(paymentRepository.findById(saved.getId())).willThrow(IllegalArgumentException.class);
 
         // when, then
-        assertThatThrownBy(() -> paymentService.canceled(saved.getId()))
+        assertThatThrownBy(() -> paymentService.cancel(saved.getId()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 구현 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 거절 시 결제 취소 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
주문이 거절되는 경우 해당 결제 건의 `status`를 `CANCELED`로 변경한다.
