### PR TITLE
[POM-94] feat: 가게 정보 등록, 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/ray/pominowner/store/controller/StoreController.java
+++ b/src/main/java/com/ray/pominowner/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.ray.pominowner.store.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pominowner.store.controller.dto.CategoryRequest;
+import com.ray.pominowner.store.controller.dto.StoreInformationRequest;
 import com.ray.pominowner.store.controller.dto.PhoneNumberRequest;
 import com.ray.pominowner.store.controller.dto.StoreRegisterRequest;
 import com.ray.pominowner.store.service.StoreService;
@@ -44,6 +45,16 @@ public class StoreController {
     @DeleteMapping("/{storeId}/phone-numbers")
     public void deletePhoneNumber(@PathVariable Long storeId) {
         storeService.deletePhoneNumber(storeId);
+    }
+
+    @PatchMapping("/{storeId}/info")
+    public void registerInformation(@RequestBody @Valid StoreInformationRequest infoRequest, @PathVariable Long storeId) {
+        storeService.registerInformation(infoRequest.information(), storeId);
+    }
+
+    @DeleteMapping("/{storeId}/info")
+    public void deleteInformation(@PathVariable Long storeId) {
+        storeService.deleteInformation(storeId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/store/controller/dto/StoreInformationRequest.java
+++ b/src/main/java/com/ray/pominowner/store/controller/dto/StoreInformationRequest.java
@@ -1,0 +1,6 @@
+package com.ray.pominowner.store.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StoreInformationRequest(@NotBlank String information) {
+}

--- a/src/main/java/com/ray/pominowner/store/domain/Information.java
+++ b/src/main/java/com/ray/pominowner/store/domain/Information.java
@@ -1,0 +1,39 @@
+package com.ray.pominowner.store.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = PROTECTED)
+public class Information {
+
+    private static final String DEFAULT_VALUE = "EMPTY";
+    private static final int MIN_INFO_LENGTH = 10;
+
+    @Column(columnDefinition = "TEXT default 'EMPTY'")
+    private String info = DEFAULT_VALUE;
+
+    public Information(String info) {
+        validateInfo(info);
+        this.info = info;
+    }
+
+    private void validateInfo(String info) {
+        Assert.hasText(info, "가게 정보는 10글자 이상이어야 합니다.");
+
+        if (info.length() < MIN_INFO_LENGTH) {
+            throw new IllegalArgumentException("가게 정보는 10글자 이상이어야 합니다.");
+        }
+    }
+
+    public String getInfo() {
+        return info;
+    }
+
+}

--- a/src/main/java/com/ray/pominowner/store/domain/Store.java
+++ b/src/main/java/com/ray/pominowner/store/domain/Store.java
@@ -15,8 +15,6 @@ import org.springframework.util.Assert;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseTimeEntity {
 
-    private static final String DEFAULT_VALUE = "NOT_SELECTED";
-
     @Id
     @Column(name = "STORE_ID")
     @GeneratedValue
@@ -25,17 +23,16 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private RequiredStoreInfo requiredStoreInfo;
 
-    @Column(columnDefinition = "TEXT default 'NOT_SELECTED'")
-    private String info = DEFAULT_VALUE;    // 선택
+    @Embedded
+    private Information info = new Information();
 
     @Embedded
-    @Column(columnDefinition = "TEXT default 'NOT_SELECTED'")
-    private PhoneNumber tel = new PhoneNumber();    // 선택
+    private PhoneNumber tel = new PhoneNumber();
 
     private Long ownerId;   // 추후 연관관계 설정 예정
 
     @Builder
-    private Store(Long id, RequiredStoreInfo requiredStoreInfo, String info, PhoneNumber tel, Long ownerId) {
+    private Store(Long id, RequiredStoreInfo requiredStoreInfo, Information info, PhoneNumber tel, Long ownerId) {
         this.id = id;
         this.requiredStoreInfo = requiredStoreInfo;
         this.info = info;
@@ -77,6 +74,26 @@ public class Store extends BaseTimeEntity {
                 .build();
     }
 
+    public Store retrieveStoreAfterRegisteringInfo(String information) {
+        return Store.builder()
+                .id(this.id)
+                .requiredStoreInfo(this.requiredStoreInfo)
+                .info(new Information(information))
+                .tel(this.tel)
+                .ownerId(this.ownerId)
+                .build();
+    }
+
+    public Store retrieveStoreAfterDeletingInfo() {
+        return Store.builder()
+                .id(this.id)
+                .requiredStoreInfo(this.requiredStoreInfo)
+                .info(new Information())
+                .tel(this.tel)
+                .ownerId(this.ownerId)
+                .build();
+    }
+
     public Long getId() {
         return id;
     }
@@ -85,4 +102,7 @@ public class Store extends BaseTimeEntity {
         return tel;
     }
 
+    public Information getInformation() {
+        return info;
+    }
 }

--- a/src/main/java/com/ray/pominowner/store/service/StoreService.java
+++ b/src/main/java/com/ray/pominowner/store/service/StoreService.java
@@ -47,6 +47,18 @@ public class StoreService {
         storeRepository.save(store);
     }
 
+    @Transactional
+    public void registerInformation(String information, Long storeId) {
+        Store store = findStore(storeId).retrieveStoreAfterRegisteringInfo(information);
+        storeRepository.save(store);
+    }
+
+    @Transactional
+    public void deleteInformation(Long storeId) {
+        Store store = findStore(storeId).retrieveStoreAfterDeletingInfo();
+        storeRepository.save(store);
+    }
+
     private Store findStore(Long storeId) {
         return storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));

--- a/src/test/java/com/ray/pominowner/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/ray/pominowner/store/controller/StoreControllerTest.java
@@ -3,6 +3,7 @@ package com.ray.pominowner.store.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ray.pominowner.store.controller.dto.CategoryRequest;
 import com.ray.pominowner.store.controller.dto.PhoneNumberRequest;
+import com.ray.pominowner.store.controller.dto.StoreInformationRequest;
 import com.ray.pominowner.store.controller.dto.StoreRegisterRequest;
 import com.ray.pominowner.store.domain.Store;
 import com.ray.pominowner.store.service.StoreService;
@@ -94,6 +95,36 @@ class StoreControllerTest {
 
         // when, then
         mvc.perform(delete("/api/v1/stores/1/phone-numbers")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("가게 정보 등록에 성공한다")
+    void successRegisterInformation() throws Exception {
+        // given
+        final String input = "가게 정보입니다. 테스트 용도입니다.";
+        StoreInformationRequest informationRequest = new StoreInformationRequest(input);
+
+        // when, then
+        mvc.perform(patch("/api/v1/stores/1/info")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(informationRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("가게 정보 삭제에 성공한다")
+    void successRemoveInformation() throws Exception {
+        // given
+        doNothing().when(storeService).deleteInformation(any(Long.class));
+
+        // when, then
+        mvc.perform(delete("/api/v1/stores/1/info")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());

--- a/src/test/java/com/ray/pominowner/store/domain/InformationTest.java
+++ b/src/test/java/com/ray/pominowner/store/domain/InformationTest.java
@@ -1,0 +1,35 @@
+package com.ray.pominowner.store.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InformationTest {
+
+    @ParameterizedTest(name = "입력값 : [{arguments}]")
+    @ValueSource(strings = {"일", "", "  "})
+    @NullSource
+    @DisplayName("10글자 미만이면 예외가 발생한다")
+    void failWhenUnderTenLetter(String information) {
+        // when, then
+        assertThatThrownBy(() -> new Information(information))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("가게 정보는 10글자 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("10글자 이상이면 생성에 성공한다")
+    void successWhenMoreThanTenLetter() {
+        // given
+        final String information = "일이삼사오육칠팔구십";
+
+        // when, then
+        assertThatNoException().isThrownBy(() -> new Information(information));
+    }
+
+}

--- a/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
+++ b/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
@@ -32,7 +32,7 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("전화번호를 등록하면 전화번호가 설정된다")
+    @DisplayName("정상적으로 전화번호가 설정된다")
     void successRegisterPhoneNumber() {
         // given
         Store store = StoreTestFixture.store();
@@ -59,7 +59,38 @@ class StoreTest {
 
         // then
         assertThat(deletedPhoneNumberStore.getPhoneNumber()).isEqualTo(new PhoneNumber());
+        assertThat(deletedPhoneNumberStore.getPhoneNumber()).isNotEqualTo(new PhoneNumber(validPhoneNumber));
     }
 
+    @Test
+    @DisplayName("정상적으로 가게 정보가 설정된다")
+    void successRegisterInformation() {
+        // given
+        Store store = StoreTestFixture.store();
+        Information validInformation = new Information("가게 정보입니다. 테스트 용도입니다.");
+
+        // when
+        Store storeAfterRegisteredPhoneNumber = store.retrieveStoreAfterRegisteringInfo(validInformation.getInfo());
+
+        // then
+        assertThat(store.getInformation()).isEqualTo(new Information());
+        assertThat(storeAfterRegisteredPhoneNumber.getInformation()).isEqualTo(validInformation);
+    }
+
+    @Test
+    @DisplayName("정상적으로 가게 정보가 삭제된다")
+    void successDeletingInformation() {
+        // given
+        String validInformation = "가게 정보입니다. 테스트 용도입니다.";
+        Store store = StoreTestFixture.store()
+                .retrieveStoreAfterRegisteringInfo(validInformation);
+
+        // when
+        Store deletedInfoStore = store.retrieveStoreAfterDeletingInfo();
+
+        // then
+        assertThat(deletedInfoStore.getInformation()).isEqualTo(new Information());
+        assertThat(deletedInfoStore.getInformation()).isNotEqualTo(new Information(validInformation));
+    }
 
 }

--- a/src/test/java/com/ray/pominowner/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ray/pominowner/store/service/StoreServiceTest.java
@@ -91,4 +91,29 @@ class StoreServiceTest {
                 .isThrownBy(() -> storeService.deletePhoneNumber(store.getId()));
     }
 
+
+    @Test
+    @DisplayName("가게 정보가 정상적으로 등록된다")
+    void successRegisterInformation() {
+        // given
+        String validInformation = "가게 정보입니다. 테스트 용 입니다.";
+        given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> storeService.registerInformation(validInformation, store.getId()));
+    }
+
+    @Test
+    @DisplayName("가게 정보가 정상적으로 삭제된다")
+    void successDeleteInformation() {
+        // given
+        given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> storeService.deleteInformation(store.getId()));
+    }
+
 }
+


### PR DESCRIPTION
## 📌 설명
- 가게 정보 기본 등록 crud 입니다.
- 각 레이어별 테스트를 작성했습니다.
- 가게 정보는 10글자 이상을 작성해야 예외를 던지지 않게 설정했습니다.

## ✅ 궁금한점
- 현재 StoreController와 StoreService에 너무 많은 메서드가 있는것 같은데, 어떤 네이밍으로 어떻게 분리하면 좋을까요?
- 가게등록, 카테고리 등록, 가게 휴대폰 번호 등록, 삭제, 가게 정보 등록 삭제 메서드가 하나의 클래스에 모두 존재합니다.
