### PR TITLE
[POM-84] refactor: Settlement관련 도메인 수정

### DIFF
--- a/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
+++ b/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
@@ -14,6 +14,7 @@ public enum ExceptionMessage {
     NULL_FEE_OBJECT("수수료 관련 값은 필수입니다."),
     NULL_PAYOUT_OBJECT("지급 관련 값은 필수입니다."),
     NULL_SALES_OBJECT("매출 관련 값은 필수입니다."),
+    NULL_DEPOSIT_STATUS("입금 상태는 필수 값입니다."),
     SALES_DATE_IS_AFTER_NOW("매출 일은 생성 날짜와 같거나 그보다 빨라야 합니다."),
     PAYOUT_DATE_IS_BEFORE_NOW("지급 일은 생성 날짜와 같거나 그보다 늦어야 합니다."),
     NO_PAYMENT("해당 결제 건이 존재하지 않습니다");

--- a/src/main/java/com/ray/pominowner/global/util/Validator.java
+++ b/src/main/java/com/ray/pominowner/global/util/Validator.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Validator {
 
-    public static void validate(boolean failureCondition, ExceptionMessage exception) {
-        if (failureCondition) {
+    public static void validate(boolean successCondition, ExceptionMessage exception) {
+        if (!successCondition) {
             throw new IllegalArgumentException(exception.getMessage());
         }
     }

--- a/src/main/java/com/ray/pominowner/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pominowner/payment/domain/Payment.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 
@@ -18,7 +19,6 @@ import static com.ray.pominowner.global.util.ExceptionMessage.INVALID_AMOUNT;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_PAYMENT_PROVIDER;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_PAYMENT_STATUS;
 import static com.ray.pominowner.global.util.Validator.validate;
-import static java.util.Objects.isNull;
 
 @Entity
 @Getter
@@ -39,9 +39,9 @@ public class Payment extends BaseTimeEntity {
 
     @Builder
     public Payment(Long id, int amount, PaymentStatus status, PGType provider) {
-        validate(amount < 0, INVALID_AMOUNT);
-        validate(isNull(status), NULL_PAYMENT_STATUS);
-        validate(isNull(provider), NULL_PAYMENT_PROVIDER);
+        validate(amount >= 0, INVALID_AMOUNT);
+        Assert.notNull(status, NULL_PAYMENT_STATUS.getMessage());
+        Assert.notNull(provider, NULL_PAYMENT_PROVIDER.getMessage());
 
         this.id = id;
         this.amount = amount;

--- a/src/main/java/com/ray/pominowner/settlement/domain/DepositStatus.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/DepositStatus.java
@@ -1,0 +1,7 @@
+package com.ray.pominowner.settlement.domain;
+
+public enum DepositStatus {
+
+    SCHEDULED, COMPLETE
+    
+}

--- a/src/main/java/com/ray/pominowner/settlement/domain/Fee.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/Fee.java
@@ -1,11 +1,14 @@
 package com.ray.pominowner.settlement.domain;
 
+import com.ray.pominowner.payment.domain.PGType;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 import static com.ray.pominowner.global.util.ExceptionMessage.INVALID_AMOUNT;
+import static com.ray.pominowner.global.util.ExceptionMessage.NULL_PAYMENT_PROVIDER;
 import static com.ray.pominowner.global.util.Validator.validate;
 
 @Embeddable
@@ -13,20 +16,27 @@ import static com.ray.pominowner.global.util.Validator.validate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Fee {
 
+    private static final double BROKERAGE_FEE = 0.06;
+
+    private static final double VALUE_ADDED_FEE = 0.01;
+
     private int paymentFee;
 
     private int brokerageFee;
 
     private int valueAddedFee;
 
-    public Fee(int paymentFee, int brokerageFee, int valueAddedFee) {
-        validate(paymentFee < 0, INVALID_AMOUNT);
-        validate(brokerageFee < 0, INVALID_AMOUNT);
-        validate(valueAddedFee < 0, INVALID_AMOUNT);
+    public Fee(PGType pgType, int paymentAmount) {
+        Assert.notNull(pgType, NULL_PAYMENT_PROVIDER.getMessage());
+        validate(paymentAmount >= 0, INVALID_AMOUNT);
 
-        this.paymentFee = paymentFee;
-        this.brokerageFee = brokerageFee;
-        this.valueAddedFee = valueAddedFee;
+        this.paymentFee = pgType.calculate(paymentAmount);
+        this.brokerageFee = (int) (paymentAmount * BROKERAGE_FEE);
+        this.valueAddedFee = (int) (paymentAmount * VALUE_ADDED_FEE);
+    }
+
+    public int calculateTotalMinusAmount() {
+        return paymentFee + brokerageFee + valueAddedFee;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/domain/PayOut.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/PayOut.java
@@ -5,10 +5,12 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 import java.time.LocalDate;
 
 import static com.ray.pominowner.global.util.ExceptionMessage.INVALID_AMOUNT;
+import static com.ray.pominowner.global.util.ExceptionMessage.NULL_FEE_OBJECT;
 import static com.ray.pominowner.global.util.ExceptionMessage.PAYOUT_DATE_IS_BEFORE_NOW;
 import static com.ray.pominowner.global.util.Validator.validate;
 
@@ -22,12 +24,21 @@ public class PayOut {
 
     private LocalDate payOutDate;
 
-    public PayOut(int payOutAmount, LocalDate payOutDate) {
-        validate(payOutAmount < 0, INVALID_AMOUNT);
-        validate(payOutDate.isBefore(LocalDate.now()), PAYOUT_DATE_IS_BEFORE_NOW);
+    public PayOut(int paymentAmount, Fee fee, LocalDate payOutDate) {
+        Assert.notNull(fee, NULL_FEE_OBJECT.getMessage());
+        validate(paymentAmount >= 0, INVALID_AMOUNT);
+        validate(payOutDate.isAfter(LocalDate.now()) || payOutDate.isEqual(LocalDate.now()), PAYOUT_DATE_IS_BEFORE_NOW);
+
+        int payOutAmount = paymentAmount - fee.calculateTotalMinusAmount();
+        validate(payOutAmount >= 0, INVALID_AMOUNT);  // 추후 처리 예정
 
         this.payOutAmount = payOutAmount;
         this.payOutDate = payOutDate;
+    }
+
+    public LocalDate calculatePayoutDate(LocalDate orderedAt) {
+        // 추후 구현 예정
+        return orderedAt;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/domain/PayOut.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/PayOut.java
@@ -25,15 +25,19 @@ public class PayOut {
     private LocalDate payOutDate;
 
     public PayOut(int paymentAmount, Fee fee, LocalDate payOutDate) {
-        Assert.notNull(fee, NULL_FEE_OBJECT.getMessage());
-        validate(paymentAmount >= 0, INVALID_AMOUNT);
-        validate(payOutDate.isAfter(LocalDate.now()) || payOutDate.isEqual(LocalDate.now()), PAYOUT_DATE_IS_BEFORE_NOW);
+        validatePayOut(paymentAmount, fee, payOutDate);
 
         int payOutAmount = paymentAmount - fee.calculateTotalMinusAmount();
         validate(payOutAmount >= 0, INVALID_AMOUNT);  // 추후 처리 예정
 
         this.payOutAmount = payOutAmount;
         this.payOutDate = payOutDate;
+    }
+
+    private void validatePayOut(int paymentAmount, Fee fee, LocalDate payOutDate) {
+        Assert.notNull(fee, NULL_FEE_OBJECT.getMessage());
+        validate(paymentAmount >= 0, INVALID_AMOUNT);
+        validate(payOutDate.isAfter(LocalDate.now()) || payOutDate.isEqual(LocalDate.now()), PAYOUT_DATE_IS_BEFORE_NOW);
     }
 
     public LocalDate calculatePayoutDate(LocalDate orderedAt) {

--- a/src/main/java/com/ray/pominowner/settlement/domain/Sales.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/Sales.java
@@ -23,12 +23,12 @@ public class Sales {
 
     private LocalDate salesDate;
 
-    public Sales(int salesAmount, LocalDate salesDate) {
+    public Sales(int salesAmount, LocalDate orderedAt) {
         validate(salesAmount >= 0, INVALID_AMOUNT);
         validate(orderedAt.isBefore(LocalDate.now()) || orderedAt.isEqual(LocalDate.now()), SALES_DATE_IS_AFTER_NOW);
 
         this.salesAmount = salesAmount;
-        this.salesDate = salesDate;
+        this.salesDate = orderedAt;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/domain/Sales.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/Sales.java
@@ -24,8 +24,8 @@ public class Sales {
     private LocalDate salesDate;
 
     public Sales(int salesAmount, LocalDate salesDate) {
-        validate(salesAmount < 0, INVALID_AMOUNT);
-        validate(salesDate.isAfter(LocalDate.now()), SALES_DATE_IS_AFTER_NOW);
+        validate(salesAmount >= 0, INVALID_AMOUNT);
+        validate(orderedAt.isBefore(LocalDate.now()) || orderedAt.isEqual(LocalDate.now()), SALES_DATE_IS_AFTER_NOW);
 
         this.salesAmount = salesAmount;
         this.salesDate = salesDate;

--- a/src/main/java/com/ray/pominowner/settlement/domain/Settlement.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/Settlement.java
@@ -7,17 +7,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
+import org.springframework.util.Assert;
 
+import java.util.Objects;
+
+import static com.ray.pominowner.global.util.ExceptionMessage.NULL_DEPOSIT_STATUS;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_FEE_OBJECT;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_PAYOUT_OBJECT;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_SALES_OBJECT;
-import static com.ray.pominowner.global.util.Validator.validate;
-import static java.util.Objects.isNull;
 
 @Entity
-@EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Settlement extends BaseTimeEntity {
 
@@ -35,23 +37,48 @@ public class Settlement extends BaseTimeEntity {
     @Embedded
     private Sales sales;
 
+    private DepositStatus depositStatus;
+
     private Long storeId;
 
     private Long orderId;
 
     private Long paymentId;
 
-    public Settlement(Fee fee, PayOut payOut, Sales sales, Long storeId, Long orderId, Long paymentId) {
-        validate(isNull(fee), NULL_FEE_OBJECT);
-        validate(isNull(payOut), NULL_PAYOUT_OBJECT);
-        validate(isNull(sales), NULL_SALES_OBJECT);
+    private boolean deleted;
+
+    @Builder
+    public Settlement(Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus, Long storeId, Long orderId, Long paymentId, boolean deleted) {
+        validateSettlement(fee, payOut, sales, depositStatus);
 
         this.fee = fee;
         this.payOut = payOut;
         this.sales = sales;
+        this.depositStatus = depositStatus;
         this.storeId = storeId;
         this.orderId = orderId;
         this.paymentId = paymentId;
+        this.deleted = deleted;
+    }
+
+    private void validateSettlement(Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus) {
+        Assert.notNull(fee, NULL_FEE_OBJECT.getMessage());
+        Assert.notNull(payOut, NULL_PAYOUT_OBJECT.getMessage());
+        Assert.notNull(sales, NULL_SALES_OBJECT.getMessage());
+        Assert.notNull(depositStatus, NULL_DEPOSIT_STATUS.getMessage());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Settlement that = (Settlement) o;
+        return id != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
     }
 
 }

--- a/src/test/java/com/ray/pominowner/settlement/domain/FeeTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/domain/FeeTest.java
@@ -1,5 +1,6 @@
 package com.ray.pominowner.settlement.domain;
 
+import com.ray.pominowner.payment.domain.PGType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,29 +18,24 @@ class FeeTest {
     @DisplayName("Fee 생성에 성공한다.")
     public void successFee() {
         // given, when
-        Fee fee = new Fee(1000, 1000, 1000);
+        Fee fee = new Fee(PGType.TOSS, 10000);
 
         // then
         assertThat(fee).isNotNull();
     }
 
-    @ParameterizedTest(name = "[{index}] payment : {0}, brokerage : {1}, valueAdded : {2}")
+    @ParameterizedTest(name = "[{index}] pgType : {0}, payAmount : {1}")
     @MethodSource("invalidFee")
     @DisplayName("필드 값이 유효하지 않은 경우 Fee 생성에 실패한다.")
-    public void failFee(int payment, int brokerage, int valueAdded) {
-        assertThatThrownBy(() -> new Fee(payment, brokerage, valueAdded))
+    public void failFee(PGType pgType, int payAmount) {
+        assertThatThrownBy(() -> new Fee(pgType, payAmount))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     static Stream<Arguments> invalidFee() {
         return Stream.of(
-                Arguments.arguments(-1000, -1000, -1000),
-                Arguments.arguments(-1000, -1000, 1000),
-                Arguments.arguments(-1000, 1000, -1000),
-                Arguments.arguments(-1000, 1000, 1000),
-                Arguments.arguments(1000, -1000, -1000),
-                Arguments.arguments(1000, -1000, 1000),
-                Arguments.arguments(1000, 1000, -1000)
+                Arguments.arguments(null, 1000),
+                Arguments.arguments(null, -1000)
         );
     }
 

--- a/src/test/java/com/ray/pominowner/settlement/domain/PayOutTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/domain/PayOutTest.java
@@ -1,5 +1,6 @@
 package com.ray.pominowner.settlement.domain;
 
+import com.ray.pominowner.payment.domain.PGType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,29 +15,35 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PayOutTest {
 
+    private static final Fee fee = new Fee(PGType.TOSS, 10000);
+
     @Test
     @DisplayName("Payout 생성에 성공한다.")
     public void successPayout() {
         // given, when
-        PayOut payOut = new PayOut(1000, LocalDate.now());
+        PayOut payOut = new PayOut(10000, fee, LocalDate.now());
 
         // then
         assertThat(payOut).isNotNull();
     }
 
-    @ParameterizedTest(name = "[{index}] amount : {0}, date : {1}")
+    @ParameterizedTest(name = "[{index}] paymentAmount : {0}, fee: {1} payoutDate : {2}")
     @MethodSource("invalidPayout")
     @DisplayName("필드 값이 유효하지 않은 경우 Payout 생성에 실패한다.")
-    public void failPayout(int amount, LocalDate date) {
-        assertThatThrownBy(() -> new PayOut(amount, date))
+    public void failPayout(int paymentAmount, Fee fee, LocalDate payoutDate) {
+        assertThatThrownBy(() -> new PayOut(paymentAmount, fee, payoutDate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     static Stream<Arguments> invalidPayout() {
         return Stream.of(
-                Arguments.arguments(1000, LocalDate.now().minusDays(1)),
-                Arguments.arguments(-1000, LocalDate.now()),
-                Arguments.arguments(-1000, LocalDate.now().minusDays(1))
+                Arguments.arguments(-1000, null, LocalDate.now().minusDays(1)),
+                Arguments.arguments(-1000, null, LocalDate.now()),
+                Arguments.arguments(-1000, fee, LocalDate.now().minusDays(1)),
+                Arguments.arguments(-1000, fee, LocalDate.now()),
+                Arguments.arguments(1000, null, LocalDate.now().minusDays(1)),
+                Arguments.arguments(1000, null, LocalDate.now()),
+                Arguments.arguments(1000, fee, LocalDate.now().minusDays(1))
         );
     }
 

--- a/src/test/java/com/ray/pominowner/settlement/domain/SalesTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/domain/SalesTest.java
@@ -24,11 +24,11 @@ class SalesTest {
         assertThat(sales).isNotNull();
     }
 
-    @ParameterizedTest(name = "[{index}] amount : {0}, date : {1}")
+    @ParameterizedTest(name = "[{index}] salesAmount : {0}, orderedAt : {1}")
     @MethodSource("invalidSales")
     @DisplayName("필드 값이 유효하지 않은 경우 Sales 생성에 실패한다.")
-    public void failSales(int amount, LocalDate date) {
-        assertThatThrownBy(() -> new Sales(amount, date))
+    public void failSales(int salesAmount, LocalDate orderedAt) {
+        assertThatThrownBy(() -> new Sales(salesAmount, orderedAt))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/src/test/java/com/ray/pominowner/settlement/domain/SettlementTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/domain/SettlementTest.java
@@ -1,5 +1,6 @@
 package com.ray.pominowner.settlement.domain;
 
+import com.ray.pominowner.payment.domain.PGType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,17 +15,28 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SettlementTest {
 
-    private static final Fee fee = new Fee(1000, 1000, 1000);
+    private static final Fee fee = new Fee(PGType.TOSS, 10000);
 
-    private static final PayOut payOut = new PayOut(1000, LocalDate.now().plusDays(1));
+    private static final PayOut payOut = new PayOut(10000, fee, LocalDate.now().plusDays(1));
 
     private static final Sales sales = new Sales(1000, LocalDate.now());
+
 
     @Test
     @DisplayName("Settlement 생성에 성공한다.")
     public void successSettlement() {
         // given, when
-        Settlement settlement = new Settlement(fee, payOut, sales, 1L, 1L, 1L);
+        Settlement settlement = Settlement.builder()
+                .fee(fee)
+                .payOut(payOut)
+                .sales(sales)
+                .depositStatus(DepositStatus.SCHEDULED)
+                .storeId(1L)
+                .orderId(1L)
+                .paymentId(1L)
+                .deleted(false)
+                .build();
+
 
         // then
         assertThat(settlement).isNotNull();
@@ -35,7 +47,16 @@ class SettlementTest {
     @DisplayName("필드 값이 유효하지 않으면 Settlement 생성에 실패한다.")
     public void failSettlement(Fee fee, PayOut payOut, Sales sales) {
         assertThatThrownBy(() ->
-                new Settlement(fee, payOut, sales, 1L, 1L, 1L))
+                Settlement.builder()
+                        .fee(fee)
+                        .payOut(payOut)
+                        .sales(sales)
+                        .depositStatus(DepositStatus.SCHEDULED)
+                        .storeId(1L)
+                        .orderId(1L)
+                        .paymentId(1L)
+                        .deleted(false)
+                        .build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 구현 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Settlement관련 도메인 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

**Fee(수수료)**
- PG사 타입과 결제 금액을 받아서 계산하여 컬럼에 값 넣기
- paymentFee: PG사 수수료 적용
- brokerageFee, valueAddedFee: 지정한 수수료 적용

**PayOut(지불)**
- 지급 지불 금액을 계산하기 위해 생성자 파라미터에 Fee추가

**Sales(매출)**
- salesDate -> orderedAt으로 변수명 수정

**Settlement(정산)**
- 정산 상태, 삭제 여부 컬럼 추가

**전체 반영 사향**
- validate형식 팀 컨벤션으로 통일
