### PR TITLE
[POM-94] 가게 이미지 업로드 기능 추가

### DIFF
--- a/src/main/java/com/ray/pominowner/global/config/ImagePathProvider.java
+++ b/src/main/java/com/ray/pominowner/global/config/ImagePathProvider.java
@@ -1,0 +1,20 @@
+package com.ray.pominowner.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class ImagePathProvider {
+
+    private final String storeImageRootPath;
+    private final String storeLogoImageSubPath;
+
+    public ImagePathProvider(@Value("${file.store.image.path}") String storeImageRootPath,
+                             @Value("${file.store.logo.path}") String storeLogoImageSubPath) {
+        this.storeImageRootPath = storeImageRootPath;
+        this.storeLogoImageSubPath = storeLogoImageSubPath;
+    }
+
+}

--- a/src/main/java/com/ray/pominowner/store/controller/StoreController.java
+++ b/src/main/java/com/ray/pominowner/store/controller/StoreController.java
@@ -60,7 +60,7 @@ public class StoreController {
 
     @PostMapping("/{storeId}/store-image")
     public void saveStoreImage(@RequestBody @Valid StoreImageRequest requestImages, @PathVariable Long storeId) {
-        storeService.saveStoreImage(requestImages.images(), storeId);
+        storeService.saveStoreImages(requestImages.images(), storeId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/store/controller/StoreController.java
+++ b/src/main/java/com/ray/pominowner/store/controller/StoreController.java
@@ -61,8 +61,8 @@ public class StoreController {
     }
 
     @PostMapping(value = "/{storeId}/store-images", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public void saveStoreImage(@RequestBody List<MultipartFile> multipartFiles, @PathVariable Long storeId) {
-        storeService.saveStoreImages(multipartFiles, storeId);
+    public void saveStoreImage(@RequestBody List<MultipartFile> images, @PathVariable Long storeId) {
+        storeService.saveStoreImages(images, storeId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/store/controller/StoreController.java
+++ b/src/main/java/com/ray/pominowner/store/controller/StoreController.java
@@ -2,8 +2,9 @@ package com.ray.pominowner.store.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pominowner.store.controller.dto.CategoryRequest;
-import com.ray.pominowner.store.controller.dto.StoreInformationRequest;
 import com.ray.pominowner.store.controller.dto.PhoneNumberRequest;
+import com.ray.pominowner.store.controller.dto.StoreImageRequest;
+import com.ray.pominowner.store.controller.dto.StoreInformationRequest;
 import com.ray.pominowner.store.controller.dto.StoreRegisterRequest;
 import com.ray.pominowner.store.service.StoreService;
 import jakarta.validation.Valid;
@@ -55,6 +56,11 @@ public class StoreController {
     @DeleteMapping("/{storeId}/info")
     public void deleteInformation(@PathVariable Long storeId) {
         storeService.deleteInformation(storeId);
+    }
+
+    @PostMapping("/{storeId}/store-image")
+    public void saveStoreImage(@RequestBody @Valid StoreImageRequest requestImages, @PathVariable Long storeId) {
+        storeService.saveStoreImage(requestImages.images(), storeId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/store/controller/StoreController.java
+++ b/src/main/java/com/ray/pominowner/store/controller/StoreController.java
@@ -3,12 +3,12 @@ package com.ray.pominowner.store.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pominowner.store.controller.dto.CategoryRequest;
 import com.ray.pominowner.store.controller.dto.PhoneNumberRequest;
-import com.ray.pominowner.store.controller.dto.StoreImageRequest;
 import com.ray.pominowner.store.controller.dto.StoreInformationRequest;
 import com.ray.pominowner.store.controller.dto.StoreRegisterRequest;
 import com.ray.pominowner.store.service.StoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,8 +17,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/stores")
@@ -58,9 +60,9 @@ public class StoreController {
         storeService.deleteInformation(storeId);
     }
 
-    @PostMapping("/{storeId}/store-image")
-    public void saveStoreImage(@RequestBody @Valid StoreImageRequest requestImages, @PathVariable Long storeId) {
-        storeService.saveStoreImages(requestImages.images(), storeId);
+    @PostMapping(value = "/{storeId}/store-images", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public void saveStoreImage(@RequestBody List<MultipartFile> multipartFiles, @PathVariable Long storeId) {
+        storeService.saveStoreImages(multipartFiles, storeId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/store/controller/dto/StoreImageRequest.java
+++ b/src/main/java/com/ray/pominowner/store/controller/dto/StoreImageRequest.java
@@ -1,0 +1,9 @@
+package com.ray.pominowner.store.controller.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record StoreImageRequest (@NotEmpty List<MultipartFile> images) {
+}

--- a/src/main/java/com/ray/pominowner/store/controller/dto/StoreImageRequest.java
+++ b/src/main/java/com/ray/pominowner/store/controller/dto/StoreImageRequest.java
@@ -1,9 +1,0 @@
-package com.ray.pominowner.store.controller.dto;
-
-import jakarta.validation.constraints.NotEmpty;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-
-public record StoreImageRequest (@NotEmpty List<MultipartFile> images) {
-}

--- a/src/main/java/com/ray/pominowner/store/domain/Store.java
+++ b/src/main/java/com/ray/pominowner/store/domain/Store.java
@@ -6,12 +6,20 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.ALL;
+
 @Entity
+@EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseTimeEntity {
 
@@ -29,14 +37,18 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private PhoneNumber tel = new PhoneNumber();
 
+    @OneToMany(mappedBy = "store", cascade = ALL, orphanRemoval = true)
+    private List<StoreImage> images = new ArrayList<>();
+
     private Long ownerId;   // 추후 연관관계 설정 예정
 
     @Builder
-    private Store(Long id, RequiredStoreInfo requiredStoreInfo, Information info, PhoneNumber tel, Long ownerId) {
+    private Store(Long id, RequiredStoreInfo requiredStoreInfo, Information info, PhoneNumber tel, List<StoreImage> images, Long ownerId) {
         this.id = id;
         this.requiredStoreInfo = requiredStoreInfo;
         this.info = info;
         this.tel = tel;
+        this.images = images;
         this.ownerId = ownerId;
     }
 
@@ -60,6 +72,7 @@ public class Store extends BaseTimeEntity {
                 .requiredStoreInfo(this.requiredStoreInfo)
                 .info(this.info)
                 .tel(new PhoneNumber(phoneNumber))
+                .images(this.images)
                 .ownerId(this.ownerId)
                 .build();
     }
@@ -70,6 +83,7 @@ public class Store extends BaseTimeEntity {
                 .requiredStoreInfo(this.requiredStoreInfo)
                 .info(this.info)
                 .tel(new PhoneNumber())
+                .images(this.images)
                 .ownerId(this.ownerId)
                 .build();
     }
@@ -80,6 +94,7 @@ public class Store extends BaseTimeEntity {
                 .requiredStoreInfo(this.requiredStoreInfo)
                 .info(new Information(information))
                 .tel(this.tel)
+                .images(this.images)
                 .ownerId(this.ownerId)
                 .build();
     }
@@ -90,6 +105,7 @@ public class Store extends BaseTimeEntity {
                 .requiredStoreInfo(this.requiredStoreInfo)
                 .info(new Information())
                 .tel(this.tel)
+                .images(this.images)
                 .ownerId(this.ownerId)
                 .build();
     }
@@ -105,4 +121,9 @@ public class Store extends BaseTimeEntity {
     public Information getInformation() {
         return info;
     }
+
+    public List<StoreImage> getImages() {
+        return images;
+    }
+
 }

--- a/src/main/java/com/ray/pominowner/store/domain/StoreImage.java
+++ b/src/main/java/com/ray/pominowner/store/domain/StoreImage.java
@@ -5,8 +5,17 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@NoArgsConstructor(access = PROTECTED)
 public class StoreImage extends BaseTimeEntity {
 
     @Id
@@ -14,8 +23,33 @@ public class StoreImage extends BaseTimeEntity {
     @GeneratedValue
     private Long id;
 
-    private String image;
+    private String path;
 
-    private Long storeId;
+    private String uploadName;
+
+    private String fileName;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "STORE_ID")
+    private Store store;
+
+    @Builder
+    private StoreImage(String path, String uploadName, String fileName, Store store) {
+        validateImage(path, uploadName, fileName);
+        this.path = path;
+        this.uploadName = uploadName;
+        this.fileName = fileName;
+        this.store = store;
+    }
+
+    private void validateImage(String path, String uploadName, String fileName) {
+        Assert.hasText(path, "경로는 빈 값일 수 없습니다.");
+        Assert.hasText(uploadName, "파일 이름은 빈 값일 수 없습니다.");
+        Assert.hasText(fileName, "파일 이름은 빈 값일 수 없습니다.");
+    }
+
+    public Store getStore() {
+        return store;
+    }
 
 }

--- a/src/main/java/com/ray/pominowner/store/repository/StoreImageRepository.java
+++ b/src/main/java/com/ray/pominowner/store/repository/StoreImageRepository.java
@@ -1,0 +1,8 @@
+package com.ray.pominowner.store.repository;
+
+import com.ray.pominowner.store.domain.StoreImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
+
+}

--- a/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
+++ b/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
@@ -69,7 +69,7 @@ public class StoreImageService {
     }
 
     private String extractFileExtension(String originalFilename) {
-        int dotIndex = originalFilename.lastIndexOf(".");
+        int dotIndex = originalFilename.lastIndexOf(DOT);
         return originalFilename.substring(dotIndex);
     }
 

--- a/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
+++ b/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
@@ -1,0 +1,76 @@
+package com.ray.pominowner.store.service;
+
+import com.ray.pominowner.global.config.ImagePathProvider;
+import com.ray.pominowner.store.domain.Store;
+import com.ray.pominowner.store.domain.StoreImage;
+import com.ray.pominowner.store.repository.StoreImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class StoreImageService {
+
+    private static final String DOT = ".";
+
+    private final ImagePathProvider imagePathProvider;
+
+    private final StoreImageRepository storeImageRepository;
+
+    public void saveImages(List<MultipartFile> images, Store store) {
+        Assert.noNullElements(images, "올바르지 못한 파일입니다.");
+        String rootPath = imagePathProvider.getStoreImageRootPath();
+        images.forEach(image -> saveEachFile(store, image, rootPath));
+    }
+
+    private void saveEachFile(Store store, MultipartFile image, String rootPath) {
+        String originalFilename = image.getOriginalFilename();
+        validateFileName(originalFilename);
+
+        String createdFileName = createFileName(originalFilename);
+        saveImageToPath(image, rootPath + createdFileName);
+
+        storeImageRepository.save(StoreImage.builder()
+                .path(rootPath + createdFileName)
+                .uploadName(originalFilename)
+                .fileName(createdFileName)
+                .store(store)
+                .build());
+    }
+
+    private void validateFileName(String originalFilename) {
+        Assert.notNull(originalFilename, "올바르지 못한 파일입니다.");
+
+        if (!originalFilename.contains(DOT)) {
+            throw new IllegalArgumentException("올바르지 못한 파일입니다.");
+        }
+    }
+
+    private void saveImageToPath(MultipartFile image, String path) {
+        try {
+            image.transferTo(new File(path));
+        } catch (IOException e) {
+            throw new RuntimeException("파일 저장에 실패했습니다.",e);
+        }
+    }
+
+    private String createFileName(String originalFilename) {
+        String fileExtension = extractFileExtension(originalFilename);
+        return UUID.randomUUID()
+                .toString()
+                .concat(fileExtension);
+    }
+
+    private String extractFileExtension(String originalFilename) {
+        int dotIndex = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(dotIndex);
+    }
+
+}

--- a/src/main/java/com/ray/pominowner/store/service/StoreService.java
+++ b/src/main/java/com/ray/pominowner/store/service/StoreService.java
@@ -7,13 +7,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StoreService {
 
     private final StoreServiceValidator storeServiceValidator;
@@ -22,41 +23,41 @@ public class StoreService {
 
     private final StoreCategoryService storeCategoryService;
 
-    @Transactional
+    private final StoreImageService storeImageService;
+
     public Long registerStore(Store store) throws JsonProcessingException {
         storeServiceValidator.validateBusinessNumber(store.getBusinessNumber());
 
         return storeRepository.save(store).getId();
     }
 
-    @Transactional
     public void registerCategory(List<String> categories, Long storeId) {
         storeServiceValidator.validateCategory(categories);
         storeCategoryService.saveCategories(findStore(storeId), categories);
     }
 
-    @Transactional
     public void registerPhoneNumber(String phoneNumber, Long storeId) {
         Store store = findStore(storeId).retrieveStoreAfterRegisteringPhoneNumber(phoneNumber);
         storeRepository.save(store);
     }
 
-    @Transactional
     public void deletePhoneNumber(Long storeId) {
         Store store = findStore(storeId).retrieveStoreAfterDeletingPhoneNumber();
         storeRepository.save(store);
     }
 
-    @Transactional
     public void registerInformation(String information, Long storeId) {
         Store store = findStore(storeId).retrieveStoreAfterRegisteringInfo(information);
         storeRepository.save(store);
     }
 
-    @Transactional
     public void deleteInformation(Long storeId) {
         Store store = findStore(storeId).retrieveStoreAfterDeletingInfo();
         storeRepository.save(store);
+    }
+
+    public void saveStoreImages(List<MultipartFile> images, Long storeId) {
+        storeImageService.saveImages(images, findStore(storeId));
     }
 
     private Store findStore(Long storeId) {

--- a/src/main/resources/dev/application-dev.yml
+++ b/src/main/resources/dev/application-dev.yml
@@ -20,3 +20,10 @@ spring:
         highlight_sql: true
     defer-datasource-initialization: true
     open-in-view: false
+
+file:
+  store:
+    image:
+      path: /store-image/
+    logo:
+      path: /store-logo-image/

--- a/src/main/resources/dev/application-dev.yml
+++ b/src/main/resources/dev/application-dev.yml
@@ -21,9 +21,15 @@ spring:
     defer-datasource-initialization: true
     open-in-view: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 file:
   store:
     image:
       path: /store-image/
     logo:
       path: /store-logo-image/
+

--- a/src/main/resources/dev/application-dev.yml
+++ b/src/main/resources/dev/application-dev.yml
@@ -29,7 +29,7 @@ spring:
 file:
   store:
     image:
-      path: /store-image/
+      path: src/main/resources/store-image/
     logo:
-      path: /store-logo-image/
+      path: src/main/resources/store-logo-image/
 

--- a/src/test/java/com/ray/pominowner/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/ray/pominowner/store/controller/StoreControllerTest.java
@@ -13,10 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -127,6 +130,23 @@ class StoreControllerTest {
         mvc.perform(delete("/api/v1/stores/1/info")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("가게 이미지 저장에 성공한다")
+    void successSaveImages() throws Exception {
+        // given
+        MockMultipartFile firstMultipartFile = new MockMultipartFile("TEST", "test1.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile secondMultipartFile = new MockMultipartFile("TEST2", "test2.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+
+        // when, then
+        mvc.perform(multipart("/api/v1/stores/1/store-images")
+                        .file(firstMultipartFile)
+                        .file(secondMultipartFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/ray/pominowner/store/domain/StoreImageTest.java
+++ b/src/test/java/com/ray/pominowner/store/domain/StoreImageTest.java
@@ -1,0 +1,56 @@
+package com.ray.pominowner.store.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class StoreImageTest {
+
+    @Test
+    @DisplayName("가게 이미지에 경로, 업로드 파일이름, 저장 파일이름이 빈값, null이 아니면 엔티티 생성에 성공한다")
+    void successWhenAllElementIsNotNullOrEmpty() {
+        // given
+        final String path = "path";
+        final String uploadFileName = "uploadFileName";
+        final String saveFileName = "saveFileName";
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> StoreImage.builder()
+                        .path(path)
+                        .uploadName(uploadFileName)
+                        .fileName(saveFileName)
+                        .build());
+    }
+    
+    @ParameterizedTest(name = "[{index}] path : {0} / uploadFileName : {1} / saveFileName : {2}")
+    @DisplayName("가게 이미지에 경로, 업로드 파일 이름, 저장 파일이름이 빈값이거나 null이면 엔티티 생성이 실패한다")
+    @MethodSource("storeImageInfo")
+    void failWhenElementIsNullOrEmpty(String path, String uploadFileName, String saveFileName) {
+        // when, then
+        Assertions.assertThatThrownBy(() -> StoreImage.builder()
+                        .path(path)
+                        .uploadName(uploadFileName)
+                        .fileName(saveFileName)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
+        
+    }
+
+    static Stream<Arguments> storeImageInfo() {
+        return Stream.of(
+                Arguments.arguments(null, null, null),
+                Arguments.arguments("", "", ""),
+                Arguments.arguments(" ", " ", " "),
+                Arguments.arguments("   ", "   ", "   ")
+        );
+    }
+
+}

--- a/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
+++ b/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
@@ -32,7 +32,7 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("정상적으로 전화번호가 설정된다")
+    @DisplayName("전화번호 설저에 성공한다")
     void successRegisterPhoneNumber() {
         // given
         Store store = StoreTestFixture.store();
@@ -47,8 +47,8 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("정상적으로 전화번호가 삭제된다")
-    void successDeletingPhoneNumber() {
+    @DisplayName("전화번호 삭제에 성공한다")
+    void successDeletePhoneNumber() {
         // given
         String validPhoneNumber = "010-1234-5678";
         Store store = StoreTestFixture.store()
@@ -63,7 +63,7 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("정상적으로 가게 정보가 설정된다")
+    @DisplayName("가게 정보 설정에 성공한다")
     void successRegisterInformation() {
         // given
         Store store = StoreTestFixture.store();
@@ -78,7 +78,7 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("정상적으로 가게 정보가 삭제된다")
+    @DisplayName("가게 정보 삭제에 성공한다")
     void successDeletingInformation() {
         // given
         String validInformation = "가게 정보입니다. 테스트 용도입니다.";

--- a/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
+++ b/src/test/java/com/ray/pominowner/store/domain/StoreTest.java
@@ -32,7 +32,7 @@ class StoreTest {
     }
 
     @Test
-    @DisplayName("전화번호 설저에 성공한다")
+    @DisplayName("전화번호 설정에 성공한다")
     void successRegisterPhoneNumber() {
         // given
         Store store = StoreTestFixture.store();

--- a/src/test/java/com/ray/pominowner/store/service/StoreImageServiceTest.java
+++ b/src/test/java/com/ray/pominowner/store/service/StoreImageServiceTest.java
@@ -1,0 +1,49 @@
+package com.ray.pominowner.store.service;
+
+import com.ray.pominowner.store.StoreTestFixture;
+import com.ray.pominowner.store.domain.Store;
+import com.ray.pominowner.store.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@SpringBootTest
+class StoreImageServiceTest {
+
+    @Autowired
+    private StoreImageService storeImageService;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @BeforeEach
+    void setUp() {
+        storeRepository.save(StoreTestFixture.store());
+    }
+
+    @Test
+    @DisplayName("가게 이미지 등록에 성공한다")
+    void successRegisterStoreImage() {
+        // given
+        MockMultipartFile firstMultipartFile = new MockMultipartFile("TEST", "test1.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile secondMultipartFile = new MockMultipartFile("TEST2", "test2.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        List<MultipartFile> images = List.of(firstMultipartFile, secondMultipartFile);
+        Store store = storeRepository.findById(1L).orElseThrow();
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> storeImageService.saveImages(images, store));
+    }
+
+}

--- a/src/test/java/com/ray/pominowner/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ray/pominowner/store/service/StoreServiceTest.java
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +39,9 @@ class StoreServiceTest {
     @Mock
     private StoreCategoryService storeCategoryService;
 
+    @Mock
+    private StoreImageService storeImageService;
+
     private Store store;
 
     @BeforeEach
@@ -53,7 +60,6 @@ class StoreServiceTest {
         assertThatNoException()
                 .isThrownBy(() -> storeService.registerStore(store));
     }
-
 
     @Test
     @DisplayName("카테고리가 정상적으로 등록된다")
@@ -115,5 +121,17 @@ class StoreServiceTest {
                 .isThrownBy(() -> storeService.deleteInformation(store.getId()));
     }
 
-}
+    @Test
+    @DisplayName("가게 이미지가 정상적으로 등록된다")
+    void successRegisterStoreImage() {
+        // given
+        MockMultipartFile firstMultipartFile = new MockMultipartFile("TEST", "test1.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile secondMultipartFile = new MockMultipartFile("TEST2", "test2.png", MediaType.IMAGE_PNG_VALUE, UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
 
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> storeService.saveStoreImages(List.of(firstMultipartFile, secondMultipartFile), store.getId()));
+    }
+
+}


### PR DESCRIPTION
## 📌 설명
- MultiPartFile의 List를 받아 applicaion-dev.yml 경로에 저장
- 각 레이어 별 테스트 작성 완료

기능은 MultipartFile로 이미지 리스트를 받으면, 사용자가 전송한 이미지의 이름, 이미지 이름에서 확장자만 떼어 `UUID + 확장자이름`으로 application-dev.yml에 설정한 경로에 저장합니다.
따라서 StoreImage 엔티티에서는 경로, 원본 이미지 이름, 저장하는 이미지 이름(uuid)로 관리합니다.

## 참고
지난 pr시 이름 수정, 양방향 매핑, 자잘한 디렉토리 생성 및 application-dev.yml 설정 수정 등으로 file Changed 수가 좀 많습니다.
여러 파일에서 조금씩 수정하였고, 메인은 StoreImage 엔티티와 StoreImageService입니다.
다음부터 좀 더 잘게 PR을 나눠볼게요
