### PR TITLE
[POM-80] feat: menu 이미지 저장 경로 설정 및 파일 저장 기능 global로 분리를 통한 리펙토링

### DIFF
--- a/src/main/java/com/ray/pominowner/global/config/ImagePathProvider.java
+++ b/src/main/java/com/ray/pominowner/global/config/ImagePathProvider.java
@@ -10,11 +10,14 @@ public class ImagePathProvider {
 
     private final String storeImageRootPath;
     private final String storeLogoImageSubPath;
+    private final String menuImageRootPath;
 
     public ImagePathProvider(@Value("${file.store.image.path}") String storeImageRootPath,
-                             @Value("${file.store.logo.path}") String storeLogoImageSubPath) {
+                             @Value("${file.store.logo.path}") String storeLogoImageSubPath,
+                             @Value("${file.menu.image.path}") String menuImageRootPath) {
         this.storeImageRootPath = storeImageRootPath;
         this.storeLogoImageSubPath = storeLogoImageSubPath;
+        this.menuImageRootPath = menuImageRootPath;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/global/vo/FileInfo.java
+++ b/src/main/java/com/ray/pominowner/global/vo/FileInfo.java
@@ -1,0 +1,5 @@
+package com.ray.pominowner.global.vo;
+
+public record FileInfo(String originalFileName, String createdFileName) {
+
+}

--- a/src/main/java/com/ray/pominowner/global/vo/FileSaver.java
+++ b/src/main/java/com/ray/pominowner/global/vo/FileSaver.java
@@ -1,0 +1,54 @@
+package com.ray.pominowner.global.vo;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class FileSaver {
+
+    private static final String DOT = ".";
+
+    public FileInfo retrieveFileInfoAfterSavingFile(MultipartFile image, String rootPath) {
+        String originalFilename = image.getOriginalFilename();
+        validateFileName(originalFilename);
+
+        String createdFileName = createFileName(originalFilename);
+        saveImageToPath(image, rootPath + createdFileName);
+
+        return new FileInfo(originalFilename, createdFileName);
+    }
+
+    private void validateFileName(String originalFilename) {
+        Assert.notNull(originalFilename, "올바르지 못한 파일입니다.");
+
+        if (!originalFilename.contains(DOT)) {
+            throw new IllegalArgumentException("올바르지 못한 파일입니다.");
+        }
+    }
+
+    private String createFileName(String originalFilename) {
+        String fileExtension = extractFileExtension(originalFilename);
+        return UUID.randomUUID()
+                .toString()
+                .concat(fileExtension);
+    }
+
+    private String extractFileExtension(String originalFilename) {
+        int dotIndex = originalFilename.lastIndexOf(DOT);
+        return originalFilename.substring(dotIndex);
+    }
+
+    private void saveImageToPath(MultipartFile image, String path) {
+        try {
+            image.transferTo(new File(path));
+        } catch (IOException e) {
+            throw new RuntimeException("파일 저장에 실패했습니다.",e);
+        }
+    }
+
+}

--- a/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
+++ b/src/main/java/com/ray/pominowner/store/service/StoreImageService.java
@@ -1,6 +1,8 @@
 package com.ray.pominowner.store.service;
 
 import com.ray.pominowner.global.config.ImagePathProvider;
+import com.ray.pominowner.global.vo.FileInfo;
+import com.ray.pominowner.global.vo.FileSaver;
 import com.ray.pominowner.store.domain.Store;
 import com.ray.pominowner.store.domain.StoreImage;
 import com.ray.pominowner.store.repository.StoreImageRepository;
@@ -9,20 +11,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class StoreImageService {
 
-    private static final String DOT = ".";
-
     private final ImagePathProvider imagePathProvider;
 
     private final StoreImageRepository storeImageRepository;
+
+    private final FileSaver fileSaver;
 
     public void saveImages(List<MultipartFile> images, Store store) {
         Assert.noNullElements(images, "올바르지 못한 파일입니다.");
@@ -31,11 +30,9 @@ public class StoreImageService {
     }
 
     private void saveEachFile(Store store, MultipartFile image, String rootPath) {
-        String originalFilename = image.getOriginalFilename();
-        validateFileName(originalFilename);
-
-        String createdFileName = createFileName(originalFilename);
-        saveImageToPath(image, rootPath + createdFileName);
+        FileInfo fileInfo = fileSaver.retrieveFileInfoAfterSavingFile(image, rootPath);
+        final String createdFileName = fileInfo.createdFileName();
+        final String originalFilename = fileInfo.originalFileName();
 
         storeImageRepository.save(StoreImage.builder()
                 .path(rootPath + createdFileName)
@@ -43,34 +40,6 @@ public class StoreImageService {
                 .fileName(createdFileName)
                 .store(store)
                 .build());
-    }
-
-    private void validateFileName(String originalFilename) {
-        Assert.notNull(originalFilename, "올바르지 못한 파일입니다.");
-
-        if (!originalFilename.contains(DOT)) {
-            throw new IllegalArgumentException("올바르지 못한 파일입니다.");
-        }
-    }
-
-    private void saveImageToPath(MultipartFile image, String path) {
-        try {
-            image.transferTo(new File(path));
-        } catch (IOException e) {
-            throw new RuntimeException("파일 저장에 실패했습니다.",e);
-        }
-    }
-
-    private String createFileName(String originalFilename) {
-        String fileExtension = extractFileExtension(originalFilename);
-        return UUID.randomUUID()
-                .toString()
-                .concat(fileExtension);
-    }
-
-    private String extractFileExtension(String originalFilename) {
-        int dotIndex = originalFilename.lastIndexOf(DOT);
-        return originalFilename.substring(dotIndex);
     }
 
 }

--- a/src/main/resources/dev/application-dev.yml
+++ b/src/main/resources/dev/application-dev.yml
@@ -32,4 +32,7 @@ file:
       path: src/main/resources/store-image/
     logo:
       path: src/main/resources/store-logo-image/
+  menu:
+    image:
+      path: src/main/resources/menu-image/
 


### PR DESCRIPTION
## 📌 설명
- storeImageService 에서 담당하던 물리적인 파일 저장 기능을 FileSaver로 분리.
- 파일 원래 이름, 저장 이름 다루는 vo 분리

## 추후 진행사항
- 메뉴 등록 기능 추가
- 테스트 리펙토링
