### PR TITLE
[POM-81] feat: 사장이 주문 수락 시 예상 대기 시간을 설정할 수 있다

### DIFF
--- a/src/main/java/com/ray/pominowner/orders/controller/OrderController.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.ray.pominowner.orders.controller;
 
+import com.ray.pominowner.orders.controller.dto.ApproveOrderRequest;
 import com.ray.pominowner.orders.controller.dto.ApproveOrderResponse;
 import com.ray.pominowner.orders.controller.dto.OrderResponse;
 import com.ray.pominowner.orders.controller.dto.ReceiveOrderRequest;
@@ -42,8 +43,8 @@ public class OrderController {
     }
 
     @PostMapping("/orders/{orderId}/approve")
-    public ApproveOrderResponse acceptOrder(@PathVariable Long orderId) {
-        Order approved = orderService.approve(orderId);
+    public ApproveOrderResponse acceptOrder(@PathVariable Long orderId, @RequestBody ApproveOrderRequest request) {
+        Order approved = orderService.approve(orderId, request.cookingMinute());
 
         return new ApproveOrderResponse(approved);
     }

--- a/src/main/java/com/ray/pominowner/orders/controller/dto/ApproveOrderRequest.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/dto/ApproveOrderRequest.java
@@ -1,0 +1,7 @@
+package com.ray.pominowner.orders.controller.dto;
+
+public record ApproveOrderRequest(
+        int cookingMinute
+) {
+
+}

--- a/src/main/java/com/ray/pominowner/orders/service/OrderService.java
+++ b/src/main/java/com/ray/pominowner/orders/service/OrderService.java
@@ -26,14 +26,14 @@ public class OrderService {
         return orderRepository.save(order);
     }
 
-    public Order approve(Long orderId) {
+    public Order approve(Long orderId, int cookingMinute) {
         Order order = orderRepository.findById(orderId).orElseThrow(
                 () -> new IllegalArgumentException("해당하는 주문이 없습니다"));
 
         Order approvedOrder = Order.of(order,
                 OrderStatus.COOKING,
                 generator.incrementAndGet(),
-                LocalTime.now().plusMinutes(15));
+                order.getOrderedAt().toLocalTime().plusMinutes(cookingMinute));
 
         orderRepository.save(approvedOrder);
 

--- a/src/test/java/com/ray/pominowner/orders/controller/OrderControllerTest.java
+++ b/src/test/java/com/ray/pominowner/orders/controller/OrderControllerTest.java
@@ -2,6 +2,7 @@ package com.ray.pominowner.orders.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ray.pominowner.global.domain.PhoneNumber;
+import com.ray.pominowner.orders.controller.dto.ApproveOrderRequest;
 import com.ray.pominowner.orders.controller.dto.ReceiveOrderRequest;
 import com.ray.pominowner.orders.domain.Order;
 import com.ray.pominowner.orders.service.OrderService;
@@ -21,6 +22,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -109,12 +111,15 @@ class OrderControllerTest {
     @WithMockUser
     @DisplayName("주문 수락을 성공한다")
     void successApproveOrder() throws Exception {
-        given(orderService.approve(any(Long.class))).willReturn(order);
+        given(orderService.approve(any(Long.class), any(Integer.class))).willReturn(order);
+
+        ApproveOrderRequest request = new ApproveOrderRequest(90);
 
         this.mockMvc.perform(post("/api/v1/orders/1/approve")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .param("orderId", "1"))
+                        .param("orderId", "1")
+                        .content(mapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print());
     }

--- a/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.orders.service;
 
 import com.ray.pominowner.global.domain.PhoneNumber;
+import com.ray.pominowner.orders.controller.dto.ApproveOrderRequest;
 import com.ray.pominowner.orders.domain.Order;
 import com.ray.pominowner.orders.domain.OrderStatus;
 import com.ray.pominowner.orders.repository.OrderRepository;
@@ -76,13 +77,16 @@ class OrderServiceTest {
         given(orderRepository.findById(1L)).willReturn(Optional.ofNullable(order));
         given(generator.incrementAndGet()).willReturn(1);
 
+        ApproveOrderRequest request = new ApproveOrderRequest(90);
+
         // when
-        Order approvedOrder = orderService.approve(order.getId());
+        Order approvedOrder = orderService.approve(order.getId(), request.cookingMinute());
 
         // then
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("status", OrderStatus.COOKING);
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("receiptNumber", 1);
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("estimatedCookingTime", approvedOrder.getEstimatedCookingTime());
+        assertThat(approvedOrder.getEstimatedCookingTime().isAfter(approvedOrder.getOrderedAt().toLocalTime())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 사장이 주문을 수락할 경우 예상 대기 시간을 분 단위의 숫자로 서버에 넘겨준다
- 서버는 해당 분 단위의 숫자를 받아 주문 시각 (orderedAt) 에 해당 분만큼의 시간을 더한 결과를 Order 엔티티에 estimatedCookingTime 필드에 저장한다
