### PR TITLE
[POM-76] feat: 일 정산 조회 기능 구현

### DIFF
--- a/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
+++ b/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
@@ -21,7 +21,9 @@ public enum ExceptionMessage {
     NO_PAYMENT("해당 결제 건이 존재하지 않습니다"),
     NO_ORDER("해당 주문 건이 존재하지 않습니다."),
     NO_SETTLEMENT("해당 결제 건이 존재하지 않습니다."),
-    INVALID_ORDER("취소되거나 거절된 주문입니다.");
+    NO_STORE("해당 가게가 존재하지 않습니다."),
+    INVALID_ORDER("취소되거나 거절된 주문입니다."),
+    INVALID_DATE_TYPE("유요하지 않은 기준 날짜 타입입니다.");
 
     private final String message;
 

--- a/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
+++ b/src/main/java/com/ray/pominowner/global/util/ExceptionMessage.java
@@ -15,6 +15,7 @@ public enum ExceptionMessage {
     NULL_PAYOUT_OBJECT("지급 관련 값은 필수입니다."),
     NULL_SALES_OBJECT("매출 관련 값은 필수입니다."),
     NULL_DEPOSIT_STATUS("입금 상태는 필수 값입니다."),
+    NULL_SERVICE_TYPE("서비스 타입은 필수 값입니다."),
     SALES_DATE_IS_AFTER_NOW("매출 일은 생성 날짜와 같거나 그보다 빨라야 합니다."),
     PAYOUT_DATE_IS_BEFORE_NOW("지급 일은 생성 날짜와 같거나 그보다 늦어야 합니다."),
     NO_PAYMENT("해당 결제 건이 존재하지 않습니다");

--- a/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/dto/ReceiveOrderRequest.java
@@ -9,6 +9,7 @@ import com.ray.pominowner.settlement.domain.DepositStatus;
 import com.ray.pominowner.settlement.domain.Fee;
 import com.ray.pominowner.settlement.domain.PayOut;
 import com.ray.pominowner.settlement.domain.Sales;
+import com.ray.pominowner.settlement.domain.ServiceType;
 import com.ray.pominowner.settlement.domain.Settlement;
 
 import java.time.LocalDateTime;
@@ -58,6 +59,7 @@ public record ReceiveOrderRequest(
                 .payOut(new PayOut(payment.amount(), fee, orderedAt.toLocalDate()))
                 .sales(new Sales(payment.amount(), orderedAt.toLocalDate()))
                 .depositStatus(DepositStatus.SCHEDULED)
+                .serviceType(ServiceType.PACKAGING)
                 .storeId(storeId)
                 .orderId(id)
                 .paymentId(payment.id())

--- a/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
+++ b/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.settlement.controller;
 
 import com.ray.pominowner.settlement.controller.dto.SettlementResponse;
+import com.ray.pominowner.settlement.controller.vo.SettlementByStoreRequest;
 import com.ray.pominowner.settlement.service.DateType;
 import com.ray.pominowner.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class SettlementController {
 
     @GetMapping("/by-store/{storeId}")
     public List<SettlementResponse> getDailySettlementByStore(@PathVariable Long storeId, @RequestParam DateType dateType, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
-        return settlementService.getDailySettlementByStore(storeId, dateType, startDate, endDate)
+        return settlementService.getDailySettlementByStore(new SettlementByStoreRequest(storeId, dateType, startDate, endDate))
                 .stream()
                 .map(SettlementResponse::new)
                 .toList();

--- a/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
+++ b/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.settlement.controller;
 
 import com.ray.pominowner.settlement.controller.dto.SettlementResponse;
+import com.ray.pominowner.settlement.service.DateType;
 import com.ray.pominowner.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +23,14 @@ public class SettlementController {
     @GetMapping("/byOrder/{orderId}")
     public SettlementResponse getSettlementByOrder(@PathVariable Long orderId) {
         return new SettlementResponse(settlementService.getSettlementByOrder(orderId));
+    }
+
+    @GetMapping("/byStore/{storeId}")
+    public List<SettlementResponse> getDailySettlementByStore(@PathVariable Long storeId, @RequestParam DateType dateType, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
+        return settlementService.getDailySettlementByStore(storeId, dateType, startDate, endDate)
+                .stream()
+                .map(SettlementResponse::new)
+                .toList();
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
+++ b/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
@@ -20,12 +20,12 @@ public class SettlementController {
 
     private final SettlementService settlementService;
 
-    @GetMapping("/byOrder/{orderId}")
+    @GetMapping("/by-order/{orderId}")
     public SettlementResponse getSettlementByOrder(@PathVariable Long orderId) {
         return new SettlementResponse(settlementService.getSettlementByOrder(orderId));
     }
 
-    @GetMapping("/byStore/{storeId}")
+    @GetMapping("/by-store/{storeId}")
     public List<SettlementResponse> getDailySettlementByStore(@PathVariable Long storeId, @RequestParam DateType dateType, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
         return settlementService.getDailySettlementByStore(storeId, dateType, startDate, endDate)
                 .stream()

--- a/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
+++ b/src/main/java/com/ray/pominowner/settlement/controller/SettlementController.java
@@ -16,9 +16,9 @@ public class SettlementController {
 
     private final SettlementService settlementService;
 
-    @GetMapping
-    public SettlementResponse getSettlementInfoByOrder(@RequestParam("orderId") Long orderId) {
-        return settlementService.getSettlementByOrder(orderId);
+    @GetMapping("/byOrder/{orderId}")
+    public SettlementResponse getSettlementByOrder(@PathVariable Long orderId) {
+        return new SettlementResponse(settlementService.getSettlementByOrder(orderId));
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/controller/vo/SettlementByStoreRequest.java
+++ b/src/main/java/com/ray/pominowner/settlement/controller/vo/SettlementByStoreRequest.java
@@ -1,0 +1,9 @@
+package com.ray.pominowner.settlement.controller.vo;
+
+import com.ray.pominowner.settlement.service.DateType;
+
+import java.time.LocalDate;
+
+public record SettlementByStoreRequest(Long storeId, DateType dateType, LocalDate startDate, LocalDate endDate) {
+
+}

--- a/src/main/java/com/ray/pominowner/settlement/domain/ServiceType.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/ServiceType.java
@@ -1,0 +1,7 @@
+package com.ray.pominowner.settlement.domain;
+
+public enum ServiceType {
+
+    PACKAGING
+    
+}

--- a/src/main/java/com/ray/pominowner/settlement/domain/Settlement.java
+++ b/src/main/java/com/ray/pominowner/settlement/domain/Settlement.java
@@ -4,6 +4,8 @@ import com.ray.pominowner.global.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -18,6 +20,7 @@ import static com.ray.pominowner.global.util.ExceptionMessage.NULL_DEPOSIT_STATU
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_FEE_OBJECT;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_PAYOUT_OBJECT;
 import static com.ray.pominowner.global.util.ExceptionMessage.NULL_SALES_OBJECT;
+import static com.ray.pominowner.global.util.ExceptionMessage.NULL_SERVICE_TYPE;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,7 +39,11 @@ public class Settlement extends BaseTimeEntity {
     @Embedded
     private Sales sales;
 
+    @Enumerated(EnumType.STRING)
     private DepositStatus depositStatus;
+
+    @Enumerated(EnumType.STRING)
+    private ServiceType serviceType;
 
     private Long storeId;
 
@@ -47,25 +54,27 @@ public class Settlement extends BaseTimeEntity {
     private boolean deleted;
 
     @Builder
-    public Settlement(Long id, Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus, Long storeId, Long orderId, Long paymentId, boolean deleted) {
-        validateSettlement(fee, payOut, sales, depositStatus);
+    public Settlement(Long id, Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus, ServiceType serviceType, Long storeId, Long orderId, Long paymentId, boolean deleted) {
+        validateSettlement(fee, payOut, sales, depositStatus, serviceType);
 
         this.id = id;
         this.fee = fee;
         this.payOut = payOut;
         this.sales = sales;
         this.depositStatus = depositStatus;
+        this.serviceType = serviceType;
         this.storeId = storeId;
         this.orderId = orderId;
         this.paymentId = paymentId;
         this.deleted = deleted;
     }
 
-    private void validateSettlement(Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus) {
+    private void validateSettlement(Fee fee, PayOut payOut, Sales sales, DepositStatus depositStatus, ServiceType serviceType) {
         Assert.notNull(fee, NULL_FEE_OBJECT.getMessage());
         Assert.notNull(payOut, NULL_PAYOUT_OBJECT.getMessage());
         Assert.notNull(sales, NULL_SALES_OBJECT.getMessage());
         Assert.notNull(depositStatus, NULL_DEPOSIT_STATUS.getMessage());
+        Assert.notNull(serviceType, NULL_SERVICE_TYPE.getMessage());
     }
 
     @Override

--- a/src/main/java/com/ray/pominowner/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/ray/pominowner/settlement/repository/SettlementRepository.java
@@ -3,10 +3,16 @@ package com.ray.pominowner.settlement.repository;
 import com.ray.pominowner.settlement.domain.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 
     Optional<Settlement> findSettlementByOrderIdAndDeleted(Long orderId, boolean deleted);
+
+    List<Settlement> findSettlementsByStoreIdAndDeletedAndSales_SalesDateBetween(Long storeId, boolean deleted, LocalDate startDate, LocalDate endDate);
+    
+    List<Settlement> findSettlementsByStoreIdAndDeletedAndPayOut_PayOutDateBetween(Long storeId, boolean deleted, LocalDate startDate, LocalDate endDate);
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/service/DateType.java
+++ b/src/main/java/com/ray/pominowner/settlement/service/DateType.java
@@ -1,24 +1,24 @@
 package com.ray.pominowner.settlement.service;
 
+import com.ray.pominowner.settlement.controller.vo.SettlementByStoreRequest;
 import com.ray.pominowner.settlement.domain.Settlement;
 import com.ray.pominowner.settlement.repository.SettlementRepository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public enum DateType {
     SOLD {
         @Override
-        public List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate) {
-            return settlementRepository.findSettlementsByStoreIdAndDeletedAndSales_SalesDateBetween(storeId, false, startDate, endDate);
+        public List<Settlement> getSettlements(SettlementRepository settlementRepository, SettlementByStoreRequest request) {
+            return settlementRepository.findSettlementsByStoreIdAndDeletedAndSales_SalesDateBetween(request.storeId(), false, request.startDate(), request.endDate());
         }
     },
     PAYOUT {
         @Override
-        public List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate) {
-            return settlementRepository.findSettlementsByStoreIdAndDeletedAndPayOut_PayOutDateBetween(storeId, false, startDate, endDate);
+        public List<Settlement> getSettlements(SettlementRepository settlementRepository, SettlementByStoreRequest request) {
+            return settlementRepository.findSettlementsByStoreIdAndDeletedAndPayOut_PayOutDateBetween(request.storeId(), false, request.startDate(), request.endDate());
         }
     };
 
-    public abstract List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate);
+    public abstract List<Settlement> getSettlements(SettlementRepository settlementRepository, SettlementByStoreRequest request);
 }

--- a/src/main/java/com/ray/pominowner/settlement/service/DateType.java
+++ b/src/main/java/com/ray/pominowner/settlement/service/DateType.java
@@ -1,0 +1,24 @@
+package com.ray.pominowner.settlement.service;
+
+import com.ray.pominowner.settlement.domain.Settlement;
+import com.ray.pominowner.settlement.repository.SettlementRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public enum DateType {
+    SOLD {
+        @Override
+        public List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate) {
+            return settlementRepository.findSettlementsByStoreIdAndDeletedAndSales_SalesDateBetween(storeId, false, startDate, endDate);
+        }
+    },
+    PAYOUT {
+        @Override
+        public List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate) {
+            return settlementRepository.findSettlementsByStoreIdAndDeletedAndPayOut_PayOutDateBetween(storeId, false, startDate, endDate);
+        }
+    };
+
+    public abstract List<Settlement> getSettlements(SettlementRepository settlementRepository, Long storeId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
+++ b/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.settlement.service;
 
 import com.ray.pominowner.orders.repository.OrderRepository;
+import com.ray.pominowner.settlement.controller.vo.SettlementByStoreRequest;
 import com.ray.pominowner.settlement.domain.Settlement;
 import com.ray.pominowner.settlement.repository.SettlementRepository;
 import com.ray.pominowner.store.repository.StoreRepository;
@@ -39,11 +40,11 @@ public class SettlementService {
                 .orElseThrow(() -> new IllegalArgumentException(NO_SETTLEMENT.getMessage()));
     }
 
-    public List<Settlement> getDailySettlementByStore(Long storeId, DateType dateType, LocalDate startDate, LocalDate endDate) {
-        storeRepository.findById(storeId)
+    public List<Settlement> getDailySettlementByStore(SettlementByStoreRequest request) {
+        storeRepository.findById(request.storeId())
                 .orElseThrow(() -> new IllegalArgumentException(NO_STORE.getMessage()));
 
-        return dateType.getSettlements(settlementRepository, storeId, startDate, endDate);
+        return request.dateType().getSettlements(settlementRepository, request);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
+++ b/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
@@ -1,15 +1,19 @@
 package com.ray.pominowner.settlement.service;
 
 import com.ray.pominowner.orders.repository.OrderRepository;
-import com.ray.pominowner.settlement.controller.dto.SettlementResponse;
 import com.ray.pominowner.settlement.domain.Settlement;
 import com.ray.pominowner.settlement.repository.SettlementRepository;
+import com.ray.pominowner.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import static com.ray.pominowner.global.util.ExceptionMessage.NO_ORDER;
 import static com.ray.pominowner.global.util.ExceptionMessage.NO_SETTLEMENT;
+import static com.ray.pominowner.global.util.ExceptionMessage.NO_STORE;
 
 @Service
 @Transactional
@@ -19,6 +23,8 @@ public class SettlementService {
     private final SettlementRepository settlementRepository;
 
     private final OrderRepository orderRepository;
+
+    private final StoreRepository storeRepository;
 
     public Settlement create(Settlement settlement) {
         return settlementRepository.save(settlement);
@@ -33,7 +39,11 @@ public class SettlementService {
                 .orElseThrow(() -> new IllegalArgumentException(NO_SETTLEMENT.getMessage()));
     }
 
-        return new SettlementResponse(settlement);
+    public List<Settlement> getDailySettlementByStore(Long storeId, DateType dateType, LocalDate startDate, LocalDate endDate) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException(NO_STORE.getMessage()));
+
+        return dateType.getSettlements(settlementRepository, storeId, startDate, endDate);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
+++ b/src/main/java/com/ray/pominowner/settlement/service/SettlementService.java
@@ -24,13 +24,14 @@ public class SettlementService {
         return settlementRepository.save(settlement);
     }
 
-    public SettlementResponse getSettlementByOrder(Long orderId) {
+    public Settlement getSettlementByOrder(Long orderId) {
         orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException(NO_ORDER.getMessage()))
                 .validateStatus();
 
-        Settlement settlement = settlementRepository.findSettlementByOrderIdAndDeleted(orderId, false)
+        return settlementRepository.findSettlementByOrderIdAndDeleted(orderId, false)
                 .orElseThrow(() -> new IllegalArgumentException(NO_SETTLEMENT.getMessage()));
+    }
 
         return new SettlementResponse(settlement);
     }

--- a/src/test/java/com/ray/pominowner/settlement/SettlementTestFixture.java
+++ b/src/test/java/com/ray/pominowner/settlement/SettlementTestFixture.java
@@ -5,6 +5,7 @@ import com.ray.pominowner.settlement.domain.DepositStatus;
 import com.ray.pominowner.settlement.domain.Fee;
 import com.ray.pominowner.settlement.domain.PayOut;
 import com.ray.pominowner.settlement.domain.Sales;
+import com.ray.pominowner.settlement.domain.ServiceType;
 import com.ray.pominowner.settlement.domain.Settlement;
 
 import java.time.LocalDate;
@@ -30,6 +31,7 @@ public final class SettlementTestFixture {
                 .payOut(payOut())
                 .sales(sales())
                 .depositStatus(DepositStatus.SCHEDULED)
+                .serviceType(ServiceType.PACKAGING)
                 .storeId(1L)
                 .orderId(1L)
                 .paymentId(1L)

--- a/src/test/java/com/ray/pominowner/settlement/domain/SettlementTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/domain/SettlementTest.java
@@ -41,6 +41,7 @@ class SettlementTest {
                         .payOut(payOut)
                         .sales(sales)
                         .depositStatus(DepositStatus.SCHEDULED)
+                        .serviceType(ServiceType.PACKAGING)
                         .storeId(1L)
                         .orderId(1L)
                         .paymentId(1L)

--- a/src/test/java/com/ray/pominowner/settlement/service/SettlementServiceTest.java
+++ b/src/test/java/com/ray/pominowner/settlement/service/SettlementServiceTest.java
@@ -68,10 +68,10 @@ class SettlementServiceTest {
         given(settlementRepository.findSettlementByOrderIdAndDeleted(order.getId(), false)).willReturn(Optional.of(settlement()));
 
         // when
-        SettlementResponse settlementResponse = settlementService.getSettlementByOrder(order.getId());
+        Settlement settlement = settlementService.getSettlementByOrder(order.getId());
 
         // then
-        assertThat(new SettlementResponse(settlement())).isEqualTo(settlementResponse);
+        assertThat(new SettlementResponse(settlement())).isEqualTo(new SettlementResponse(settlement));
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 구현 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
일 정산 조회 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Settlement 엔티티에 서비스 타입 컬럼 추가
- 일 정산 조회 controller, repository, service 구현
- 주문 목록 별 정산 조회 service의 리턴 타입 엔티티로 변경

## 🫡 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
`controller` 나름 고심한 URI인데 어떤지 의견 주시거나 더 좋은 의견 있다면 남겨주세요👍

+) 테스트 코드, 조회한 날이 정산 전인 경우 처리 추후 할 예정