### PR TITLE
[POM-80] 옵션 도메인 로직 작성 및 테스트

### DIFF
--- a/src/main/java/com/ray/pominowner/menu/domain/Option.java
+++ b/src/main/java/com/ray/pominowner/menu/domain/Option.java
@@ -5,8 +5,20 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@Getter
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor(access = PROTECTED)
 public class Option extends BaseTimeEntity {
 
     @Id
@@ -18,6 +30,41 @@ public class Option extends BaseTimeEntity {
 
     private int price;
 
-    private Long optionGroupId;
+    private boolean selected;
+
+    @ManyToOne
+    @JoinColumn(name = "OPTION_GROUP_ID")
+    private OptionGroup optionGroup;
+
+    @Builder
+    private Option(Long id, String name, int price, boolean selected, OptionGroup optionGroup) {
+        validateConstructor(name, price, optionGroup);
+
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.selected = selected;
+        this.optionGroup = optionGroup;
+    }
+
+    private void validateConstructor(String name, int price, OptionGroup optionGroup) {
+        Assert.hasText(name, "옵션 이름은 필수입니다.");
+        Assert.isTrue(price >= 0, "잘못된 가격을 입력하셨습니다.");
+        Assert.notNull(optionGroup, "옵션 그룹 선택은 필수입니다.");
+    }
+
+    public Option changeSelectionStatus(boolean selected) {
+        if (this.selected == selected) {
+           return this;
+        }
+
+        return Option.builder()
+                .id(this.id)
+                .name(this.name)
+                .price(this.price)
+                .selected(selected)
+                .optionGroup(this.optionGroup)
+                .build();
+    }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
+++ b/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
@@ -5,8 +5,22 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.FetchType.EAGER;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor(access = PROTECTED)
 public class OptionGroup extends BaseTimeEntity {
 
     @Id
@@ -22,6 +36,60 @@ public class OptionGroup extends BaseTimeEntity {
 
     private Long storeId;
 
-    // Option과 양방향 매핑
+    @OneToMany(mappedBy = "optionGroup", fetch = EAGER, orphanRemoval = true, cascade = PERSIST)
+    private final List<Option> options = new ArrayList<>();
+
+    @Builder
+    private OptionGroup(Long id, String name, int maxOptionCount, boolean required, Long storeId) {
+        validateConstructor(name, maxOptionCount);
+
+        this.id = id;
+        this.name = name;
+        this.maxOptionCount = maxOptionCount;
+        this.required = required;
+        this.storeId = storeId;
+    }
+
+    private void validateConstructor(String name, int maxOptionCount) {
+        Assert.hasText(name, "옵션 그룹 이름은 필수입니다.");
+        Assert.isTrue(maxOptionCount >= 0, "최대 옵션 개수는 0 이상이어야 합니다.");
+    }
+
+    public void add(Option option) {
+        Option changeOptionGroup = Option.builder()
+                .id(option.getId())
+                .name(option.getName())
+                .price(option.getPrice())
+                .selected(option.isSelected())
+                .optionGroup(this)
+                .build();
+
+        this.options.add(changeOptionGroup);
+        checkOptionCount();
+    }
+
+    public int getTotalPrice() {
+        return this.options.stream()
+                .filter(Option::isSelected)
+                .mapToInt(Option::getPrice)
+                .sum();
+    }
+
+    private void checkOptionCount() {
+        long totalCheckedOptionCount = this.options.stream().filter(Option::isSelected).count();
+        if (this.maxOptionCount < totalCheckedOptionCount) {
+            throw new IllegalArgumentException("최대 옵션 개수를 초과하였습니다.");
+        }
+    }
+
+    public void checkRequiredOption() {
+        if (this.required && this.options.stream().noneMatch(Option::isSelected)) {
+            throw new IllegalArgumentException("필수 옵션을 선택해주세요.");
+        }
+    }
+
+    public List<Option> getOptions() {
+        return options;
+    }
 
 }

--- a/src/test/java/com/ray/pominowner/menu/domain/OptionTest.java
+++ b/src/test/java/com/ray/pominowner/menu/domain/OptionTest.java
@@ -1,0 +1,200 @@
+package com.ray.pominowner.menu.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class OptionTest {
+
+    private OptionGroup optionGroup;
+
+    private List<Option> selectedOptions;
+
+    @BeforeEach
+    void setUp() {
+        optionGroup = OptionGroup.builder()
+                .name("첫번째 옵션 그룹")
+                .maxOptionCount(3)
+                .required(true)
+                .storeId(1L)
+                .build();
+
+        Option firstOption = Option.builder()
+                .name("옵션 1")
+                .price(500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option secondOption = Option.builder()
+                .name("옵션 2")
+                .price(700)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option thirdOption = Option.builder()
+                .name("옵션 3")
+                .price(1500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option fourthOption = Option.builder()
+                .name("옵션 4")
+                .price(1500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+
+        selectedOptions = List.of(firstOption, secondOption, thirdOption, fourthOption);
+    }
+
+    @Test
+    @DisplayName("옵선 생성에 성공한다")
+    void successGeneratingOption() {
+
+        // given
+        Option firstOption = selectedOptions.get(0);
+
+        // when
+        optionGroup.add(firstOption);
+
+        // then
+        assertThat(optionGroup.getOptions())
+                .hasSize(1)
+                .contains(firstOption);
+    }
+
+    @Test
+    @DisplayName("옵션 가격을 성공적으로 가져온다")
+    void successCalculatingPrice() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when
+        int totalPrice = optionGroup.getTotalPrice();
+
+        // then
+        int expectedPrice = 2_700;
+        assertThat(totalPrice).isEqualTo(expectedPrice);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹의 최대 선택 옵션 개수를 초과해 옵션을 선택하면 예외가 발생한다")
+    void failWhenExceedingMaxOptionCount() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+        Option fourthOption = selectedOptions.get(3);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when, then
+        assertThatThrownBy(() -> optionGroup.add(fourthOption))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹의 최대 선택 옵션 개수를 초과하지 않으면 예외가 발생하지 않는다")
+    void successWhenNotExceedingMaxOptionCount() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+        Option unSelectedFourthOption = Option.builder()
+                .name("옵션 4")
+                .price(1500)
+                .selected(false)
+                .optionGroup(optionGroup)
+                .build();
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> optionGroup.add(unSelectedFourthOption));
+    }
+
+    @Test
+    @DisplayName("옵션의 선택 상태 변경에 성공한다")
+    void successChangingOptionSelectionStatus() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+
+        Option unselectedOption = firstOption.changeSelectionStatus(false);
+
+
+        // when, then
+        assertThat(unselectedOption.isSelected()).isFalse();
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수일 경우, 옵션을 하나도 선택하지 않으면 예외가 발생한다")
+    void failWhenOptionGroupStatusIsRequiredAndNotSelectingAnyOption() {
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(false);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        assertThatThrownBy(() -> optionGroup.checkRequiredOption())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수일 경우, 옵션을 하나라도 선택할 경우 예외가 발생하지 않는다")
+    void successWhenOptionGroupStatausIsRequiredAndSelectingAtLeastOneOption() {
+        // given
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(true);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> optionGroup.checkRequiredOption());
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수가 아닐 경우, 옵션을 선택하지 않아도 예외가 발생하지 않는다")
+    void successWhenOptionGroupStatausIsNotRequiredAndNotSelectingAnyOption() {
+        // given
+        OptionGroup optionGroup = OptionGroup.builder()
+                .name("첫번째 옵션 그룹")
+                .maxOptionCount(3)
+                .required(false)
+                .storeId(1L)
+                .build();
+
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(false);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(optionGroup::checkRequiredOption);
+    }
+
+}

--- a/src/test/java/com/ray/pominowner/menu/domain/OptionTest.java
+++ b/src/test/java/com/ray/pominowner/menu/domain/OptionTest.java
@@ -1,0 +1,224 @@
+package com.ray.pominowner.menu.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class OptionTest {
+
+    private OptionGroup optionGroup;
+
+    private List<Option> selectedOptions;
+
+    @BeforeEach
+    void setUp() {
+        optionGroup = OptionGroup.builder()
+                .name("첫번째 옵션 그룹")
+                .maxOptionCount(3)
+                .required(true)
+                .storeId(1L)
+                .build();
+
+        Option firstOption = Option.builder()
+                .name("옵션 1")
+                .price(500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option secondOption = Option.builder()
+                .name("옵션 2")
+                .price(700)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option thirdOption = Option.builder()
+                .name("옵션 3")
+                .price(1500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+        Option fourthOption = Option.builder()
+                .name("옵션 4")
+                .price(1500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+
+        selectedOptions = List.of(firstOption, secondOption, thirdOption, fourthOption);
+    }
+
+    @Test
+    @DisplayName("옵선 생성에 성공한다")
+    void successGeneratingOption() {
+
+        // given
+        Option firstOption = selectedOptions.get(0);
+
+        // when
+        optionGroup.add(firstOption);
+
+        // then
+        assertThat(optionGroup.getOptions())
+                .hasSize(1)
+                .contains(firstOption);
+    }
+
+    @Test
+    @DisplayName("옵션 가격을 성공적으로 가져온다")
+    void successCalculatingPrice() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when
+        int totalPrice = optionGroup.getTotalPrice();
+
+        // then
+        int expectedPrice = 2_700;
+        assertThat(totalPrice).isEqualTo(expectedPrice);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹의 최대 선택 옵션 개수를 초과해 옵션을 선택하면 예외가 발생한다")
+    void failWhenExceedingMaxOptionCount() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+        Option fourthOption = selectedOptions.get(3);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when, then
+        assertThatThrownBy(() -> optionGroup.add(fourthOption))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹의 최대 선택 옵션 개수를 초과하지 않으면 예외가 발생하지 않는다")
+    void successWhenNotExceedingMaxOptionCount() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+        Option secondOption = selectedOptions.get(1);
+        Option thirdOption = selectedOptions.get(2);
+        Option unSelectedFourthOption = Option.builder()
+                .name("옵션 4")
+                .price(1500)
+                .selected(false)
+                .optionGroup(optionGroup)
+                .build();
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thirdOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> optionGroup.add(unSelectedFourthOption));
+    }
+
+    @Test
+    @DisplayName("옵션의 선택 상태 변경에 성공한다")
+    void successChangingOptionSelectionStatus() {
+        // given
+        Option firstOption = selectedOptions.get(0);
+
+        Option unselectedOption = firstOption.changeSelectionStatus(false);
+
+
+        // when, then
+        assertThat(unselectedOption.isSelected()).isFalse();
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수일 경우, 옵션을 하나도 선택하지 않으면 예외가 발생한다")
+    void failWhenOptionGroupStatusIsRequiredAndNotSelectingAnyOption() {
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(false);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        assertThatThrownBy(() -> optionGroup.checkRequiredOption())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수일 경우, 옵션을 하나라도 선택할 경우 예외가 발생하지 않는다")
+    void successWhenOptionGroupStatausIsRequiredAndSelectingAtLeastOneOption() {
+        // given
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(true);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> optionGroup.checkRequiredOption());
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수가 아닐 경우, 옵션을 선택하지 않아도 예외가 발생하지 않는다")
+    void successWhenOptionGroupStatausIsNotRequiredAndNotSelectingAnyOption() {
+        // given
+        OptionGroup optionGroup = OptionGroup.builder()
+                .name("첫번째 옵션 그룹")
+                .maxOptionCount(3)
+                .required(false)
+                .storeId(1L)
+                .build();
+
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(false);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(false);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(false);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(optionGroup::checkRequiredOption);
+    }
+
+    @Test
+    @DisplayName("옵션 그룹에서 옵션 선택이 필수가 아닐 경우, 옵션을 선택해도 예외가 발생하지 않는다")
+    void successWhenOptionGroupStatausIsNotRequiredAndSelectingOption() {
+        // given
+        OptionGroup optionGroup = OptionGroup.builder()
+                .name("첫번째 옵션 그룹")
+                .maxOptionCount(3)
+                .required(false)
+                .storeId(1L)
+                .build();
+
+        Option firstOption = selectedOptions.get(0).changeSelectionStatus(true);
+        Option secondOption = selectedOptions.get(1).changeSelectionStatus(true);
+        Option thridOption = selectedOptions.get(2).changeSelectionStatus(true);
+
+        optionGroup.add(firstOption);
+        optionGroup.add(secondOption);
+        optionGroup.add(thridOption);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(optionGroup::checkRequiredOption);
+    }
+
+}


### PR DESCRIPTION
## 📌 설명
옵션 그룹과 세부 옵션 항목을 일대다 양방향 매핑으로 설정했습니다. (항상 같이 조회하기 때문에)
- 선택한 옵션 가격 계산 로직 구현
- 옵션 그룹에서 선택이 필수인 경우 검증 로직 구현
- 최대 선택 가능 옵션 수 검증 로직 구현

옵션 그룹과 세부 옵션들이 항상 같이 붙어 다니기에 하나의 OptionTest 클래스에 작성했고 꼼꼼하게 상황을 검증하려 노력했습니다.
