### PR TITLE
[POM-80] feat: 옵션 등록 기능 구현

### DIFF
--- a/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.menu.controller;
 
 import com.ray.pominowner.menu.controller.dto.OptionRequest;
+import com.ray.pominowner.menu.controller.dto.OptionResponse;
 import com.ray.pominowner.menu.controller.dto.OptionUpdateRequest;
 import com.ray.pominowner.menu.domain.Option;
 import com.ray.pominowner.menu.domain.OptionGroup;
@@ -19,8 +20,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-
-import static com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse.OptionResponse;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
@@ -47,8 +47,13 @@ public class OptionController {
 
     @PutMapping
     public void updateOption(@RequestBody OptionUpdateRequest request) {
-        OptionUpdateInfo optionUpdateInfo = new OptionUpdateInfo(request.name(), request.price(), request.selected());
-        optionService.updateOption(optionUpdateInfo, request.optionId());
+        OptionUpdateInfo optionUpdateInfo = new OptionUpdateInfo(
+                request.name(),
+                request.price(),
+                request.selected(),
+                request.optionId()
+        );
+        optionService.updateOption(optionUpdateInfo);
     }
 
     @DeleteMapping

--- a/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
@@ -30,14 +30,13 @@ public class OptionController {
     private final OptionService optionService;
     private final OptionGroupService optionGroupService;
 
-    // 개별 옵션 조회
     @GetMapping
     public OptionResponse getOption(@RequestParam Long optionId) {
         Option option = optionService.getOption(optionId);
+
         return OptionResponse.from(option);
     }
 
-    // 개별 옵션 등록
     @PostMapping
     public ResponseEntity<Void> registerOption(@RequestBody OptionRequest request) {
         OptionGroup optionGroup = optionGroupService.getOptionGroup(request.optionGroupId());
@@ -46,14 +45,12 @@ public class OptionController {
         return ResponseEntity.created(URI.create("/api/v1/options/" + optionId)).build();
     }
 
-    // 개별 옵션 수정
     @PutMapping
     public void updateOption(@RequestBody OptionUpdateRequest request) {
         OptionUpdateInfo optionUpdateInfo = new OptionUpdateInfo(request.name(), request.price(), request.selected());
         optionService.updateOption(optionUpdateInfo, request.optionId());
     }
 
-    // 개별 옵션 삭제
     @DeleteMapping
     public void deleteOption(@RequestParam Long optionId) {
         optionService.deleteOption(optionId);

--- a/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionController.java
@@ -1,12 +1,26 @@
 package com.ray.pominowner.menu.controller;
 
 import com.ray.pominowner.menu.controller.dto.OptionRequest;
+import com.ray.pominowner.menu.controller.dto.OptionUpdateRequest;
+import com.ray.pominowner.menu.domain.Option;
+import com.ray.pominowner.menu.domain.OptionGroup;
+import com.ray.pominowner.menu.service.OptionGroupService;
 import com.ray.pominowner.menu.service.OptionService;
+import com.ray.pominowner.menu.service.vo.OptionUpdateInfo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+import static com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse.OptionResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,11 +28,35 @@ import org.springframework.web.bind.annotation.RestController;
 public class OptionController {
 
     private final OptionService optionService;
+    private final OptionGroupService optionGroupService;
 
-    @PostMapping
-    public void registerOption(@RequestBody OptionRequest request) {
-        optionService.registerOption(request.toEntity(), request.optionGroupId());
+    // 개별 옵션 조회
+    @GetMapping
+    public OptionResponse getOption(@RequestParam Long optionId) {
+        Option option = optionService.getOption(optionId);
+        return OptionResponse.from(option);
     }
 
+    // 개별 옵션 등록
+    @PostMapping
+    public ResponseEntity<Void> registerOption(@RequestBody OptionRequest request) {
+        OptionGroup optionGroup = optionGroupService.getOptionGroup(request.optionGroupId());
+        Long optionId = optionService.registerOption(request.toEntity(optionGroup), optionGroup);
+
+        return ResponseEntity.created(URI.create("/api/v1/options/" + optionId)).build();
+    }
+
+    // 개별 옵션 수정
+    @PutMapping
+    public void updateOption(@RequestBody OptionUpdateRequest request) {
+        OptionUpdateInfo optionUpdateInfo = new OptionUpdateInfo(request.name(), request.price(), request.selected());
+        optionService.updateOption(optionUpdateInfo, request.optionId());
+    }
+
+    // 개별 옵션 삭제
+    @DeleteMapping
+    public void deleteOption(@RequestParam Long optionId) {
+        optionService.deleteOption(optionId);
+    }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/controller/OptionGroupController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionGroupController.java
@@ -29,6 +29,7 @@ public class OptionGroupController {
     @GetMapping
     public OptionGroupWithOptionResponse getOptionGroup(@RequestParam Long optionGroupId) {
         OptionGroup optionGroup = optionGroupService.getOptionGroup(optionGroupId);
+
         return OptionGroupWithOptionResponse.from(optionGroup);
     }
 

--- a/src/main/java/com/ray/pominowner/menu/controller/OptionGroupController.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/OptionGroupController.java
@@ -1,13 +1,23 @@
 package com.ray.pominowner.menu.controller;
 
-
 import com.ray.pominowner.menu.controller.dto.OptionGroupRequest;
+import com.ray.pominowner.menu.controller.dto.OptionGroupUpdateRequest;
+import com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse;
+import com.ray.pominowner.menu.domain.OptionGroup;
 import com.ray.pominowner.menu.service.OptionGroupService;
+import com.ray.pominowner.menu.service.vo.OptionGroupUpdateInfo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,9 +26,32 @@ public class OptionGroupController {
 
     private final OptionGroupService optionGroupService;
 
+    @GetMapping
+    public OptionGroupWithOptionResponse getOptionGroup(@RequestParam Long optionGroupId) {
+        OptionGroup optionGroup = optionGroupService.getOptionGroup(optionGroupId);
+        return OptionGroupWithOptionResponse.from(optionGroup);
+    }
+
     @PostMapping
-    public void registerOptionGroup(@RequestBody OptionGroupRequest request) {
-        optionGroupService.registerOptionGroup(request.toEntity());
+    public ResponseEntity<Void> registerOptionGroup(@RequestBody OptionGroupRequest request) {
+        Long optionGroupId = optionGroupService.registerOptionGroup(request.toEntity());
+
+        return ResponseEntity.created(URI.create("/api/v1/option-groups/" + optionGroupId)).build();
+    }
+
+    @PutMapping
+    public void updateOptionGroup(@RequestBody OptionGroupUpdateRequest request) {
+        OptionGroupUpdateInfo optionGroupUpdateInfo = new OptionGroupUpdateInfo(
+                request.name(),
+                request.maxOptionCount(),
+                request.required(),
+                request.optionGroupId());
+        optionGroupService.updateOptionGroup(optionGroupUpdateInfo);
+    }
+
+    @DeleteMapping
+    public void deleteOptionGroup(@RequestParam Long optionGroupId) {
+        optionGroupService.deleteOptionGroup(optionGroupId);
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupUpdateRequest.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.ray.pominowner.menu.controller.dto;
+
+public record OptionGroupUpdateRequest(String name, int maxOptionCount, boolean required, Long optionGroupId) {
+}

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupWithOptionResponse.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupWithOptionResponse.java
@@ -1,10 +1,8 @@
 package com.ray.pominowner.menu.controller.dto;
 
-import com.ray.pominowner.menu.domain.Option;
 import com.ray.pominowner.menu.domain.OptionGroup;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record OptionGroupWithOptionResponse(
         OptionGroupResponse optionGroupResponse,
@@ -22,28 +20,6 @@ public record OptionGroupWithOptionResponse(
     }
 
     private record OptionGroupResponse(String name, int maxOptionCount, boolean required) {
-    }
-
-    public record OptionResponse(String name, int price, boolean selected) {
-
-        public static List<OptionResponse> from(List<Option> options) {
-            return options.stream()
-                    .map(option -> new OptionResponse(
-                            option.getName(),
-                            option.getPrice(),
-                            option.isSelected()
-                    ))
-                    .collect(Collectors.toList());
-        }
-
-        public static OptionResponse from(Option option) {
-            return new OptionResponse(
-                    option.getName(),
-                    option.getPrice(),
-                    option.isSelected()
-            );
-        }
-
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupWithOptionResponse.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionGroupWithOptionResponse.java
@@ -1,0 +1,51 @@
+package com.ray.pominowner.menu.controller.dto;
+
+import com.ray.pominowner.menu.domain.Option;
+import com.ray.pominowner.menu.domain.OptionGroup;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record OptionGroupWithOptionResponse(
+        OptionGroupResponse optionGroupResponse,
+        List<OptionResponse> optionResponses) {
+
+    public static OptionGroupWithOptionResponse from(OptionGroup optionGroup) {
+        return new OptionGroupWithOptionResponse(
+                new OptionGroupResponse(
+                        optionGroup.getName(),
+                        optionGroup.getMaxOptionCount(),
+                        optionGroup.isRequired()
+                ),
+                OptionResponse.from(optionGroup.getOptions())
+        );
+    }
+
+    private record OptionGroupResponse(String name, int maxOptionCount, boolean required) {
+    }
+
+    public record OptionResponse(String name, int price, boolean selected) {
+
+        public static List<OptionResponse> from(List<Option> options) {
+            return options.stream()
+                    .map(option -> new OptionResponse(
+                            option.getName(),
+                            option.getPrice(),
+                            option.isSelected()
+                    ))
+                    .collect(Collectors.toList());
+        }
+
+        public static OptionResponse from(Option option) {
+            return new OptionResponse(
+                    option.getName(),
+                    option.getPrice(),
+                    option.isSelected()
+            );
+        }
+
+    }
+
+}
+
+

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionRequest.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionRequest.java
@@ -1,14 +1,16 @@
 package com.ray.pominowner.menu.controller.dto;
 
 import com.ray.pominowner.menu.domain.Option;
+import com.ray.pominowner.menu.domain.OptionGroup;
 
 public record OptionRequest(String name, int price, boolean selected, Long optionGroupId) {
 
-    public Option toEntity() {
+    public Option toEntity(OptionGroup optionGroup) {
         return Option.builder()
                 .name(name)
                 .price(price)
                 .selected(selected)
+                .optionGroup(optionGroup)
                 .build();
     }
 

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionResponse.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionResponse.java
@@ -1,0 +1,27 @@
+package com.ray.pominowner.menu.controller.dto;
+
+import com.ray.pominowner.menu.domain.Option;
+
+import java.util.List;
+
+public record OptionResponse(String name, int price, boolean selected) {
+
+    public static List<OptionResponse> from(List<Option> options) {
+        return options.stream()
+                .map(option -> new OptionResponse(
+                        option.getName(),
+                        option.getPrice(),
+                        option.isSelected()
+                ))
+                .toList();
+    }
+
+    public static OptionResponse from(Option option) {
+        return new OptionResponse(
+                option.getName(),
+                option.getPrice(),
+                option.isSelected()
+        );
+    }
+
+}

--- a/src/main/java/com/ray/pominowner/menu/controller/dto/OptionUpdateRequest.java
+++ b/src/main/java/com/ray/pominowner/menu/controller/dto/OptionUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.ray.pominowner.menu.controller.dto;
+
+public record OptionUpdateRequest(String name, int price, boolean selected, Long optionId) {
+}

--- a/src/main/java/com/ray/pominowner/menu/domain/Option.java
+++ b/src/main/java/com/ray/pominowner/menu/domain/Option.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.menu.domain;
 
 import com.ray.pominowner.global.domain.BaseTimeEntity;
+import com.ray.pominowner.menu.service.vo.OptionUpdateInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -65,6 +66,20 @@ public class Option extends BaseTimeEntity {
                 .selected(selected)
                 .optionGroup(this.optionGroup)
                 .build();
+    }
+
+    public Option update(OptionUpdateInfo request) {
+        return Option.builder()
+                .id(this.id)
+                .name(request.name())
+                .price(request.price())
+                .selected(request.selected())
+                .optionGroup(this.optionGroup)
+                .build();
+    }
+
+    public Long getId() {
+        return id;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
+++ b/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
@@ -1,6 +1,7 @@
 package com.ray.pominowner.menu.domain;
 
 import com.ray.pominowner.global.domain.BaseTimeEntity;
+import com.ray.pominowner.menu.service.vo.OptionGroupUpdateInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -8,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
@@ -20,11 +22,10 @@ import static jakarta.persistence.FetchType.EAGER;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@Getter
 @EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = PROTECTED)
 public class OptionGroup extends BaseTimeEntity {
-
-    private static final int MAX_OPTION_COUNT = 10;
 
     @Id
     @Column(name = "OPTION_GROUP_ID")
@@ -58,7 +59,7 @@ public class OptionGroup extends BaseTimeEntity {
         Assert.isTrue(maxOptionCount >= 0, "최대 옵션 개수는 0 이상이어야 합니다.");
     }
 
-    public void addOption(Option option) {
+    public Option addOption(Option option) {
         Option optionGroupChangedOption = Option.builder()
                 .id(option.getId())
                 .name(option.getName())
@@ -70,10 +71,14 @@ public class OptionGroup extends BaseTimeEntity {
         this.options.add(optionGroupChangedOption);
         checkMaxOptionCount();
         checkSelectedOptionCount();
+
+        return optionGroupChangedOption;
     }
 
     private void checkMaxOptionCount() {
-        if (options.size() > MAX_OPTION_COUNT) {
+        final int maxOptionCount = 10;
+
+        if (options.size() > maxOptionCount) {
             throw new IllegalArgumentException("옵션 개수는 10개를 초과할 수 없습니다.");
         }
     }
@@ -98,8 +103,22 @@ public class OptionGroup extends BaseTimeEntity {
         }
     }
 
+    public OptionGroup update(OptionGroupUpdateInfo optionGroupUpdateInfo) {
+        return OptionGroup.builder()
+                .id(id)
+                .name(optionGroupUpdateInfo.name())
+                .maxOptionCount(optionGroupUpdateInfo.maxOptionCount())
+                .required(optionGroupUpdateInfo.required())
+                .storeId(storeId)
+                .build();
+    }
+
     public List<Option> getOptions() {
         return options;
+    }
+
+    public Long getId() {
+        return id;
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
+++ b/src/main/java/com/ray/pominowner/menu/domain/OptionGroup.java
@@ -79,7 +79,7 @@ public class OptionGroup extends BaseTimeEntity {
         final int maxOptionCount = 10;
 
         if (options.size() > maxOptionCount) {
-            throw new IllegalArgumentException("옵션 개수는 10개를 초과할 수 없습니다.");
+            throw new IllegalArgumentException("옵션 개수는 " + maxOptionCount + "개를 초과할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/ray/pominowner/menu/repository/OptionRepository.java
+++ b/src/main/java/com/ray/pominowner/menu/repository/OptionRepository.java
@@ -1,0 +1,7 @@
+package com.ray.pominowner.menu.repository;
+
+import com.ray.pominowner.menu.domain.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+}

--- a/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
@@ -15,7 +15,8 @@ public class OptionGroupService {
     private final OptionGroupRepository optionGroupRepository;
 
     public OptionGroup getOptionGroup(Long optionGroupId) {
-        return findOptionGroup(optionGroupId);
+        return optionGroupRepository.findById(optionGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션그룹입니다."));
     }
 
     public Long registerOptionGroup(OptionGroup optiongroup) {
@@ -23,19 +24,14 @@ public class OptionGroupService {
     }
 
     public void updateOptionGroup(OptionGroupUpdateInfo optionGroupUpdateInfo, Long optionGroupId) {
-        OptionGroup optionGroupToUpdate = findOptionGroup(optionGroupId);
+        OptionGroup optionGroupToUpdate = getOptionGroup(optionGroupId);
         OptionGroup updatedOptionGroup = optionGroupToUpdate.update(optionGroupUpdateInfo);
         optionGroupRepository.save(updatedOptionGroup);
     }
 
     public void deleteOptionGroup(Long optionGroupId) {
-        OptionGroup optionGroup = findOptionGroup(optionGroupId);
+        OptionGroup optionGroup = getOptionGroup(optionGroupId);
         optionGroupRepository.delete(optionGroup);
-    }
-
-    private OptionGroup findOptionGroup(Long optionGroupId) {
-        return optionGroupRepository.findById(optionGroupId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션그룹입니다."));
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
@@ -23,8 +23,8 @@ public class OptionGroupService {
         return optionGroupRepository.save(optiongroup).getId();
     }
 
-    public void updateOptionGroup(OptionGroupUpdateInfo optionGroupUpdateInfo, Long optionGroupId) {
-        OptionGroup optionGroupToUpdate = getOptionGroup(optionGroupId);
+    public void updateOptionGroup(OptionGroupUpdateInfo optionGroupUpdateInfo) {
+        OptionGroup optionGroupToUpdate = getOptionGroup(optionGroupUpdateInfo.optionGroupId());
         OptionGroup updatedOptionGroup = optionGroupToUpdate.update(optionGroupUpdateInfo);
         optionGroupRepository.save(updatedOptionGroup);
     }

--- a/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionGroupService.java
@@ -2,17 +2,40 @@ package com.ray.pominowner.menu.service;
 
 import com.ray.pominowner.menu.domain.OptionGroup;
 import com.ray.pominowner.menu.repository.OptionGroupRepository;
+import com.ray.pominowner.menu.service.vo.OptionGroupUpdateInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class OptionGroupService {
 
     private final OptionGroupRepository optionGroupRepository;
 
-    public void registerOptionGroup(OptionGroup optiongroup) {
-        optionGroupRepository.save(optiongroup);
+    public OptionGroup getOptionGroup(Long optionGroupId) {
+        return findOptionGroup(optionGroupId);
+    }
+
+    public Long registerOptionGroup(OptionGroup optiongroup) {
+        return optionGroupRepository.save(optiongroup).getId();
+    }
+
+    public void updateOptionGroup(OptionGroupUpdateInfo optionGroupUpdateInfo, Long optionGroupId) {
+        OptionGroup optionGroupToUpdate = findOptionGroup(optionGroupId);
+        OptionGroup updatedOptionGroup = optionGroupToUpdate.update(optionGroupUpdateInfo);
+        optionGroupRepository.save(updatedOptionGroup);
+    }
+
+    public void deleteOptionGroup(Long optionGroupId) {
+        OptionGroup optionGroup = findOptionGroup(optionGroupId);
+        optionGroupRepository.delete(optionGroup);
+    }
+
+    private OptionGroup findOptionGroup(Long optionGroupId) {
+        return optionGroupRepository.findById(optionGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션그룹입니다."));
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/service/OptionService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionService.java
@@ -29,8 +29,8 @@ public class OptionService {
         return optionGroupAddedOption.getId();
     }
 
-    public void updateOption(OptionUpdateInfo optionUpdateInfo, Long optionId) {
-        Option option = getOption(optionId);
+    public void updateOption(OptionUpdateInfo optionUpdateInfo ) {
+        Option option = getOption(optionUpdateInfo.optionId());
         Option updatedOption = option.update(optionUpdateInfo);
         optionRepository.save(updatedOption);
     }

--- a/src/main/java/com/ray/pominowner/menu/service/OptionService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionService.java
@@ -18,7 +18,8 @@ public class OptionService {
     private final OptionRepository optionRepository;
 
     public Option getOption(Long optionId) {
-        return findOption(optionId);
+        return optionRepository.findById(optionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션입니다."));
     }
 
     public Long registerOption(Option option, OptionGroup optionGroup) {
@@ -29,19 +30,14 @@ public class OptionService {
     }
 
     public void updateOption(OptionUpdateInfo optionUpdateInfo, Long optionId) {
-        Option option = findOption(optionId);
+        Option option = getOption(optionId);
         Option updatedOption = option.update(optionUpdateInfo);
         optionRepository.save(updatedOption);
     }
 
     public void deleteOption(Long optionId) {
-        Option option = findOption(optionId);
+        Option option = getOption(optionId);
         optionRepository.delete(option);
-    }
-
-    private Option findOption(Long optionId) {
-        return optionRepository.findById(optionId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션입니다."));
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/service/OptionService.java
+++ b/src/main/java/com/ray/pominowner/menu/service/OptionService.java
@@ -3,20 +3,45 @@ package com.ray.pominowner.menu.service;
 import com.ray.pominowner.menu.domain.Option;
 import com.ray.pominowner.menu.domain.OptionGroup;
 import com.ray.pominowner.menu.repository.OptionGroupRepository;
+import com.ray.pominowner.menu.repository.OptionRepository;
+import com.ray.pominowner.menu.service.vo.OptionUpdateInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class OptionService {
 
     private final OptionGroupRepository optionGroupRepository;
+    private final OptionRepository optionRepository;
 
-    public void registerOption(Option option, Long optionGroupId) {
-        OptionGroup optionGroup = optionGroupRepository.findById(optionGroupId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션그룹입니다."));
-        optionGroup.addOption(option);
+    public Option getOption(Long optionId) {
+        return findOption(optionId);
+    }
+
+    public Long registerOption(Option option, OptionGroup optionGroup) {
+        Option optionGroupAddedOption = optionGroup.addOption(option);
         optionGroupRepository.save(optionGroup);
+
+        return optionGroupAddedOption.getId();
+    }
+
+    public void updateOption(OptionUpdateInfo optionUpdateInfo, Long optionId) {
+        Option option = findOption(optionId);
+        Option updatedOption = option.update(optionUpdateInfo);
+        optionRepository.save(updatedOption);
+    }
+
+    public void deleteOption(Long optionId) {
+        Option option = findOption(optionId);
+        optionRepository.delete(option);
+    }
+
+    private Option findOption(Long optionId) {
+        return optionRepository.findById(optionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션입니다."));
     }
 
 }

--- a/src/main/java/com/ray/pominowner/menu/service/vo/OptionGroupUpdateInfo.java
+++ b/src/main/java/com/ray/pominowner/menu/service/vo/OptionGroupUpdateInfo.java
@@ -1,0 +1,4 @@
+package com.ray.pominowner.menu.service.vo;
+
+public record OptionGroupUpdateInfo(String name, int maxOptionCount, boolean required) {
+}

--- a/src/main/java/com/ray/pominowner/menu/service/vo/OptionGroupUpdateInfo.java
+++ b/src/main/java/com/ray/pominowner/menu/service/vo/OptionGroupUpdateInfo.java
@@ -1,4 +1,4 @@
 package com.ray.pominowner.menu.service.vo;
 
-public record OptionGroupUpdateInfo(String name, int maxOptionCount, boolean required) {
+public record OptionGroupUpdateInfo(String name, int maxOptionCount, boolean required, Long optionGroupId) {
 }

--- a/src/main/java/com/ray/pominowner/menu/service/vo/OptionUpdateInfo.java
+++ b/src/main/java/com/ray/pominowner/menu/service/vo/OptionUpdateInfo.java
@@ -1,0 +1,4 @@
+package com.ray.pominowner.menu.service.vo;
+
+public record OptionUpdateInfo(String name, int price, boolean selected) {
+}

--- a/src/main/java/com/ray/pominowner/menu/service/vo/OptionUpdateInfo.java
+++ b/src/main/java/com/ray/pominowner/menu/service/vo/OptionUpdateInfo.java
@@ -1,4 +1,4 @@
 package com.ray.pominowner.menu.service.vo;
 
-public record OptionUpdateInfo(String name, int price, boolean selected) {
+public record OptionUpdateInfo(String name, int price, boolean selected, Long optionId) {
 }

--- a/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
+++ b/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
@@ -1,0 +1,131 @@
+package com.ray.pominowner.menu.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ray.pominowner.menu.controller.dto.OptionRequest;
+import com.ray.pominowner.menu.controller.dto.OptionUpdateRequest;
+import com.ray.pominowner.menu.domain.Option;
+import com.ray.pominowner.menu.domain.OptionGroup;
+import com.ray.pominowner.menu.service.OptionGroupService;
+import com.ray.pominowner.menu.service.OptionService;
+import com.ray.pominowner.menu.service.vo.OptionUpdateInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse.OptionResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OptionController.class)
+class OptionControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    private OptionService optionService;
+
+    @MockBean
+    private OptionGroupService optionGroupService;
+
+    private OptionGroup optionGroup;
+
+    private Option option;
+
+    @BeforeEach
+    void setUp() {
+        optionGroup = OptionGroup.builder()
+                .id(1L)
+                .name("옵션 그룹 1")
+                .maxOptionCount(10)
+                .required(true)
+                .storeId(1L)
+                .build();
+
+        option = Option.builder()
+                .id(1L)
+                .name("옵션 1")
+                .price(500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 조회에 성공한다")
+    void successGetOption() throws Exception {
+        // given
+        given(optionService.getOption(any(Long.class))).willReturn(option);
+        OptionResponse response = OptionResponse.from(option);
+
+        // when, then
+        mvc.perform(get("/api/v1/options")
+                        .param("optionId", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(response)));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 등록에 성공한다")
+    void successRegisterOption() throws Exception {
+        // given
+        OptionRequest optionRequest = new OptionRequest("옵션 1", 500, true, 1L);
+        given(optionGroupService.getOptionGroup(any(Long.class))).willReturn(optionGroup);
+        given(optionService.registerOption(any(Option.class), any(OptionGroup.class))).willReturn(1L);
+
+        // when, then
+        mvc.perform(post("/api/v1/options")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(optionRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(header().stringValues("Location", "/api/v1/options/1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 수정에 성공한다")
+    void successUpdateOption() throws Exception {
+        // given
+        OptionUpdateRequest optionUpdateRequest = new OptionUpdateRequest("옵션 1", 500, true, 1L);
+        doNothing().when(optionService).updateOption(any(OptionUpdateInfo.class), any(Long.class));
+
+        // when, then
+        mvc.perform(put("/api/v1/options")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(optionUpdateRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 삭제에 성공한다")
+    void successDeleteOption() throws Exception {
+        // given
+        doNothing().when(optionService).deleteOption(any(Long.class));
+
+        // when, then
+        mvc.perform(delete("/api/v1/options")
+                        .param("optionId", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
+++ b/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
@@ -2,6 +2,7 @@ package com.ray.pominowner.menu.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ray.pominowner.menu.controller.dto.OptionRequest;
+import com.ray.pominowner.menu.controller.dto.OptionResponse;
 import com.ray.pominowner.menu.controller.dto.OptionUpdateRequest;
 import com.ray.pominowner.menu.domain.Option;
 import com.ray.pominowner.menu.domain.OptionGroup;
@@ -18,7 +19,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse.OptionResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;

--- a/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
+++ b/src/test/java/com/ray/pominowner/menu/controller/OptionControllerTest.java
@@ -104,7 +104,7 @@ class OptionControllerTest {
     void successUpdateOption() throws Exception {
         // given
         OptionUpdateRequest optionUpdateRequest = new OptionUpdateRequest("옵션 1", 500, true, 1L);
-        doNothing().when(optionService).updateOption(any(OptionUpdateInfo.class), any(Long.class));
+        doNothing().when(optionService).updateOption(any(OptionUpdateInfo.class));
 
         // when, then
         mvc.perform(put("/api/v1/options")

--- a/src/test/java/com/ray/pominowner/menu/controller/OptionGroupControllerTest.java
+++ b/src/test/java/com/ray/pominowner/menu/controller/OptionGroupControllerTest.java
@@ -1,0 +1,125 @@
+package com.ray.pominowner.menu.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ray.pominowner.menu.controller.dto.OptionGroupRequest;
+import com.ray.pominowner.menu.controller.dto.OptionGroupWithOptionResponse;
+import com.ray.pominowner.menu.controller.dto.OptionUpdateRequest;
+import com.ray.pominowner.menu.domain.Option;
+import com.ray.pominowner.menu.domain.OptionGroup;
+import com.ray.pominowner.menu.service.OptionGroupService;
+import com.ray.pominowner.menu.service.vo.OptionGroupUpdateInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OptionGroupController.class)
+class OptionGroupControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    private OptionGroupService optionGroupService;
+
+    private OptionGroup optionGroup;
+
+    @BeforeEach
+    void setUp() {
+        optionGroup = OptionGroup.builder()
+                .name("옵션 그룹 1")
+                .maxOptionCount(10)
+                .required(false)
+                .storeId(1L)
+                .build();
+
+        Option option = Option.builder()
+                .id(1L)
+                .name("옵션 1")
+                .price(500)
+                .selected(true)
+                .optionGroup(optionGroup)
+                .build();
+
+        optionGroup.addOption(option);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 그룹 조회에 성공한다")
+    void successGetOption() throws Exception {
+        // given
+        OptionGroupWithOptionResponse response = OptionGroupWithOptionResponse.from(optionGroup);
+        given(optionGroupService.getOptionGroup(any(Long.class))).willReturn(optionGroup);
+
+        // when, then
+        mvc.perform(get("/api/v1/option-groups")
+                        .param("optionGroupId", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(response)));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 그룹 등록에 성공한다")
+    void successRegisterOption() throws Exception {
+        // given
+        OptionGroupRequest optionGroupRequest = new OptionGroupRequest("옵션 그룹 1", 10, false, 1L);
+        given(optionGroupService.registerOptionGroup(any(OptionGroup.class))).willReturn(1L);
+
+        // when, then
+        mvc.perform(post("/api/v1/option-groups")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(optionGroupRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(header().stringValues("Location", "/api/v1/option-groups/1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 그룹 수정에 성공한다")
+    void successUpdateOption() throws Exception {
+        // given
+        OptionUpdateRequest optionUpdateRequest = new OptionUpdateRequest("옵션 1", 500, true, 1L);
+        doNothing().when(optionGroupService).updateOptionGroup(any(OptionGroupUpdateInfo.class));
+
+        // when, then
+        mvc.perform(put("/api/v1/option-groups")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(optionUpdateRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("옵션 삭제에 성공한다")
+    void successDeleteOption() throws Exception {
+        // given
+        doNothing().when(optionGroupService).deleteOptionGroup(any(Long.class));
+
+        // when, then
+        mvc.perform(delete("/api/v1/option-groups")
+                        .param("optionGroupId", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
## 📌 설명
- 개별적인 옵션을 등록하는 crud 기능 구현입니다.
- Option 엔티티 생성시에는 반드시 OptionGroup이 설정되어 있어야 하기 때문에 optionGroup을 엔티티 생성시 설정해 주지 않으면 예외가 발생합니다. 
따라서 controller에서 optionGroup을 조회해온 뒤 온전한 option 엔티티를 생성해 저장합니다.
