### PR TITLE
fix: 테스트 하는 시점에 따라 결과가 달라지는 문제 해결

### DIFF
--- a/src/main/java/com/ray/pominowner/orders/controller/dto/ApproveOrderResponse.java
+++ b/src/main/java/com/ray/pominowner/orders/controller/dto/ApproveOrderResponse.java
@@ -2,11 +2,11 @@ package com.ray.pominowner.orders.controller.dto;
 
 import com.ray.pominowner.orders.domain.Order;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 public record ApproveOrderResponse(
         Long orderId,
-        LocalTime estimatedCookingTime,
+        LocalDateTime estimatedCookingTime,
         Integer receiptNumber
 ) {
 

--- a/src/main/java/com/ray/pominowner/orders/domain/Order.java
+++ b/src/main/java/com/ray/pominowner/orders/domain/Order.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Objects;
 
 import static com.ray.pominowner.global.util.ExceptionMessage.INVALID_ORDER;
@@ -50,7 +49,7 @@ public class Order extends BaseTimeEntity {
 
     private LocalDateTime reservationTime;
 
-    private LocalTime estimatedCookingTime;
+    private LocalDateTime estimatedCookingTime;
 
     private String rejectReason;
 
@@ -62,7 +61,7 @@ public class Order extends BaseTimeEntity {
     // Payment 와 일대일 매핑
     private Long paymentId;
 
-    public static Order of(Order order, OrderStatus status, Integer receiptNumber, LocalTime estimatedCookingTime) {
+    public static Order of(Order order, OrderStatus status, Integer receiptNumber, LocalDateTime estimatedCookingTime) {
         return Order.builder()
                 .id(order.id)
                 .orderNumber(order.orderNumber)

--- a/src/main/java/com/ray/pominowner/orders/service/OrderService.java
+++ b/src/main/java/com/ray/pominowner/orders/service/OrderService.java
@@ -34,7 +34,7 @@ public class OrderService {
         Order approvedOrder = Order.of(order,
                 OrderStatus.COOKING,
                 generator.incrementAndGet(),
-                order.getOrderedAt().toLocalTime().plusMinutes(cookingMinute));
+                order.getOrderedAt().plusMinutes(cookingMinute));
 
         orderRepository.save(approvedOrder);
 

--- a/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
+++ b/src/test/java/com/ray/pominowner/orders/service/OrderServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -83,7 +82,7 @@ class OrderServiceTest {
         given(generator.incrementAndGet()).willReturn(1);
         doNothing().when(restTemplateServiceProvider).notifyToApprove(any(Integer.class), any(Order.class));
 
-        ApproveOrderRequest request = new ApproveOrderRequest(90);
+        ApproveOrderRequest request = new ApproveOrderRequest(30);
 
         // when
         Order approvedOrder = orderService.approve(order.getId(), request.cookingMinute());
@@ -92,7 +91,7 @@ class OrderServiceTest {
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("status", OrderStatus.COOKING);
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("receiptNumber", 1);
         assertThat(approvedOrder).hasFieldOrPropertyWithValue("estimatedCookingTime", approvedOrder.getEstimatedCookingTime());
-        assertThat(approvedOrder.getEstimatedCookingTime().isAfter(approvedOrder.getOrderedAt().toLocalTime())).isTrue();
+        assertThat(approvedOrder.getEstimatedCookingTime().isAfter(approvedOrder.getOrderedAt())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 주문 예정 시각의 타입이 LocalTime 으로 되어있어 날짜가 넘어가는 경우 시간에 반영이 안되어 테스트가 실패하는 버그 수정
- ex. 9/27 23:55분에 주문을 하고 요리 시간을 30분으로 잡았다면 주문 예정 시각이 00:25 와 같이 시간값만 갖고 있어 시간값만을 비교하여 시간의 순서를 알지 못하는 경우를 해결
